### PR TITLE
revert: restore the Netlify site build to its pre-#282 state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Committing dist to allow installation from github commits and avoid tsconfig paths
 # resolution issues when using this package as a library
 # dist/
+# The pre-commit hook runs `git add dist`, so a tarball left there by a manual
+# `npm pack --pack-destination dist` would land in the repo. Never want one committed.
+dist/*.tgz
 build/
 node_modules/
 .eslintcache

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # Committing dist to allow installation from github commits and avoid tsconfig paths
 # resolution issues when using this package as a library
 # dist/
-# except the tests tarball the build emits for Netlify to serve: the pre-commit hook
-# runs `git add dist`, and this keeps that binary out of the repo.
-dist/*.tgz
 build/
 node_modules/
 .eslintcache

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,0 @@
-[build]
-  command = "npm run build"
-  publish = "dist/"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
     "description": "Materials Designer",
     "scripts": {
         "start": "vite",
-        "build": "vite build && npm run pack:tests",
-        "pack:tests": "cd tests && npm pack --pack-destination ../dist && cp ../dist/mat3ra-materials-designer-tests-0.0.0.tgz ../dist/materials-designer-tests-${COMMIT_REF:-local}.tgz",
+        "build": "vite build",
         "prepare": "husky install",
         "transpile": "tsc && npm run copy-css",
         "copy-css": "mkdir -p dist/stylesheets && cp src/stylesheets/* dist/stylesheets/",


### PR DESCRIPTION
The deployed site is currently down — https://mat3ra-materials-designer.netlify.app/ returns Netlify's own 404 page:

```bash
curl -s -o /dev/null -w "%{http_code}\n" https://mat3ra-materials-designer.netlify.app/
```

## Cause

`netlify.toml`, added in 1c24700 (#282), declared `publish = "dist/"`. This repo has two different output directories and `dist/` is the wrong one:

| dir | produced by | contents |
|---|---|---|
| `build/` | `vite build` — `outDir: "build"` in `vite.config.mts` | the app: `index.html`, `main.js`, chunks |
| `dist/` | `npm run transpile` (tsc), committed to git | the library (`"main": "dist/exports.js"`) — no `index.html` |

A `netlify.toml` overrides the Netlify UI build settings, so adding the file silently repointed the deploy from `build/` to a folder of ES modules with no entry document.

`publish = "dist/"` came from e3f8b4c, which packs the `tests/` tarball into `dist/` so deploy previews serve it over HTTPS. Serving that tarball is a reasonable goal, but it is a separate concern and does not belong in the site's publish directory.

## Change

Reverts 1c24700 and e3f8b4c:

- `netlify.toml` deleted → the Netlify UI settings govern the build again
- `package.json` → `"build": "vite build"`, `pack:tests` removed

Both are byte-identical to their pre-#282 state.

`.gitignore` deliberately **keeps** the `dist/*.tgz` ignore, with the comment reworded to drop the reference to the removed pack step. The pre-commit hook still runs `git add dist`, so a tarball left there by a manual `npm pack --pack-destination dist` would get committed into the library dir. We never want a `.tgz` in `dist/`, so the guard is worth having on its own.

The JupyterLite sidebar fix that #282 was actually for is untouched.

## Test plan

- [x] `git diff 4760a828 -- package.json netlify.toml` is empty — byte-identical to the last commit before #282. `.gitignore` differs by the intentionally-kept `dist/*.tgz` guard and nothing else.
- [x] `npm run build` emits `build/index.html` with `<title>Materials Designer</title>` and the `/main.js` entry — a servable app
- [x] No `.tgz` emitted into `build/` or `dist/`; `dist/` untouched by the build
- [x] `tests/cypress/support/widgets/JupyterLiteSession.ts` still carries the `title^="Name: …"` exact-match selector from #282

## Needs a dashboard check before this is confirmed fixed

Deleting `netlify.toml` hands control back to the UI settings, which only fixes the site if those settings were never edited. Please confirm on the `mat3ra-materials-designer` site that **publish directory** is `build` and the **build command** is what it was before Aug 3. If the UI was repointed to `dist` as well, this revert is not sufficient on its own.

## Follow-up

If the tests-tarball idea is picked up again, note that the old `pack:tests` hardcoded `mat3ra-materials-designer-tests-0.0.0.tgz`. Any bump to `tests/package.json`'s name or version makes the `cp` fail, which takes the whole `npm run build` down with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
