### PR TITLE
Feat: serve the tests tarball from the publish dir -- to use in WA tests

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,13 @@
+[build]
+  # Declared in-repo rather than left to UI-only settings so the published output is
+  # reproducible from the repo, and so the build runs `npm run build` -- which also packs
+  # the tests/ tarball that deploy previews serve for pinning an unreleased commit.
+  command = "npm run build"
+
+  # MUST stay build/, never dist/. This repo produces two unrelated outputs:
+  #   build/ -- the app, written by `vite build` (see build.outDir in vite.config.mts)
+  #   dist/  -- the tsc library output, committed to git and published to npm as
+  #             @mat3ra/materials-designer ("main": "dist/exports.js")
+  # dist/ contains no index.html, so publishing it serves Netlify's 404 page at the site
+  # root and takes the whole app offline. That regression shipped once already (#282).
+  publish = "build/"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "description": "Materials Designer",
     "scripts": {
         "start": "vite",
-        "build": "vite build",
+        "build": "vite build && npm run pack:tests",
+        "pack:tests": "mkdir -p build && cd tests && cp \"../build/$(npm pack --pack-destination ../build --silent | tail -1)\" \"../build/materials-designer-tests-${COMMIT_REF:-local}.tgz\"",
         "prepare": "husky install",
         "transpile": "tsc && npm run copy-css",
         "copy-css": "mkdir -p dist/stylesheets && cp src/stylesheets/* dist/stylesheets/",


### PR DESCRIPTION
Follow-up to #283. Restores the per-PR tests tarball that #283 reverted, this time emitting it into the directory Netlify actually publishes.

## Why we want the tarball

`tests/` is consumed by `web-app/src/tests-cypress` for Cypress step definitions. Two channels already exist:

- **released commits** → npm. `cicd.yml` publishes `./tests` as `@mat3ra/materials-designer-tests`.
- **local development** → web-app's `pack:stack-lib` + a `file:` pin.

Neither covers testing an **unmerged** materials-designer branch from CI or another machine. `npm` cannot install from a subdirectory of a git ref, and the gitpkg instance previously used for this returns 402. A tarball on the PR's own deploy preview fills that gap, at a `COMMIT_REF`-stamped URL so a pin stays immutable as the PR gets new commits.

## The change

```
"build": "vite build && npm run pack:tests",
"pack:tests": "mkdir -p build && cd tests && cp \"../build/$(npm pack --pack-destination ../build --silent | tail -1)\" \"../build/materials-designer-tests-${COMMIT_REF:-local}.tgz\"",
```

and `netlify.toml` with `publish = "build/"`.

The only difference from what #282 did is the destination directory — `build/`, not `dist/`. That one word was the outage: `vite build` writes the app to `build/` (`build.outDir` in `vite.config.mts`), while `dist/` is the committed tsc library output with no `index.html`, so publishing `dist/` served Netlify's 404 page at the site root. The `netlify.toml` comment spells this out so the trap is visible to the next person.

## Two fixes beyond a straight re-apply

Both found by running it rather than reading it:

- **The tarball filename is derived, not hardcoded.** `npm pack --silent` prints the bare filename. #282 hardcoded `mat3ra-materials-designer-tests-0.0.0.tgz`, so any name or version bump in `tests/package.json` would fail the `cp` and take all of `npm run build` down with it.
- **`mkdir -p build`.** `--pack-destination` does not create its target — it `ENOENT`s. This never surfaced before because `dist/` is committed and always exists; `build/` is gitignored, so on a fresh CI checkout it does not exist until `vite build` runs.

## Test plan

Clean run, `rm -rf build && COMMIT_REF=deadbeefcafe npm run build`:

- [x] `build/` contains `index.html` **and** `main.js` **and** both tarballs — the app and the pin coexist, which is precisely what was broken
- [x] `COMMIT_REF` stamping produces `materials-designer-tests-deadbeefcafe.tgz`
- [x] that tarball is a valid package — 182 entries, `"name": "@mat3ra/materials-designer-tests"`, carries `cypress/support/step_definitions/`
- [x] `dist/` unpolluted: no `.tgz`, no `index.html`
- [x] production site confirmed healthy on `dev` after #283 merged — `200`, `<title>Materials Designer</title>`

## After merge

Confirm on this PR's own deploy preview that **both** are served, since that is the combination that regressed:

```bash
curl -sI https://deploy-preview-284--mat3ra-materials-designer.netlify.app/ | head -1
curl -sI https://deploy-preview-284--mat3ra-materials-designer.netlify.app/materials-designer-tests-<sha>.tgz | head -1
```

## Unrelated but worth queueing

`web-app/src/tests-cypress/package.json` is pinned to PR #282's deploy-preview URL. Deploy previews are garbage-collected once the branch is deleted or retention lapses, and #282 is merged — when it goes, `npm ci` there fails with a 404. npm `@mat3ra/materials-designer-tests@2026.8.7-0` already contains the same sidebar fix and is a durable pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
