### PR TITLE
feat(status-bar): fill the footer with selection, material and position info

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,6 @@ Desirable features/fixes for implementation.
 
 General Improvements:
 
-- switch the color back to white when the material is back to the original after editing
-- show the total number of materials in the list and the current index
 - fix fullscreen support
 - add lattice vectors form to change lattice vectors in a 3x3 matrix with all components explicitly:
 - highlight atoms that are selected in the source editor in the 3D editor and vice versa

--- a/src/MDMaterial.ts
+++ b/src/MDMaterial.ts
@@ -5,8 +5,22 @@ import Material, {
 } from "@mat3ra/made/dist/js/Material";
 
 export class MDMaterial extends Material {
+    /**
+     * Signature of this material when it entered the session, used to tell "edited" from "back to
+     * how it arrived". Ephemeral and intentionally absent from {@link toJSON}: it describes the
+     * session, not the material. Left `undefined` for materials created in-session, which have no
+     * original state to return to.
+     */
+    originalSignature?: string;
+
     constructor(config: MaterialConfig = defaultMaterialConfig) {
         super(config);
+    }
+
+    clone(extraContext?: object): this {
+        const material = super.clone(extraContext);
+        material.originalSignature = this.originalSignature;
+        return material;
     }
 
     static fromMadeMaterial(madeMaterial: Material, metadata: Partial<MaterialSchema> = {}) {
@@ -29,6 +43,8 @@ export class MDMaterial extends Material {
     cleanOnCopy() {
         // @ts-expect-error MD-only runtime prop, not on MaterialSchema
         ["_id"].forEach((p) => this.unsetProp(p));
+        // A copy is a new, unsaved material: it has no original to be compared against.
+        this.originalSignature = undefined;
     }
 
     get boundaryConditions(): object {

--- a/src/MaterialsDesigner.jsx
+++ b/src/MaterialsDesigner.jsx
@@ -81,6 +81,7 @@ class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMix
             isVisibleThreeDEditorFullscreen: true,
             isVisibleJupyterLiteSessionDrawer: false,
             importMaterialsDialogProps: null,
+            selectedAtomIndices: [],
         };
         this.containerRef = React.createRef();
     }
@@ -98,6 +99,15 @@ class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMix
             // JSON.stringify calls material.toJSON(); schema failures must not white-screen the app.
             console.error("MaterialsDesigner.shouldComponentUpdate stringify failed", error);
             return true;
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        // Atom indices only mean something for the material they were picked in.
+        const hasSwitchedMaterial = prevProps.mdState.index !== this.props.mdState.index;
+        if (hasSwitchedMaterial && this.state.selectedAtomIndices.length) {
+            // eslint-disable-next-line react/no-did-update-set-state
+            this.setState({ selectedAtomIndices: [] });
         }
     }
 
@@ -121,6 +131,14 @@ class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMix
                 .map((e) => Number(e))
                 .reduce((a, b) => a + b, 0) === 1
         );
+    };
+
+    /**
+     * Atom selection lives in the 3D editor; mirroring it here lets the status bar (and, later,
+     * the source editor) describe what the user has picked.
+     */
+    onSelectionChanged = (selectedAtomIndices) => {
+        this.setState({ selectedAtomIndices: selectedAtomIndices || [] });
     };
 
     onSectionVisibilityToggle = (componentName) => {
@@ -278,6 +296,9 @@ class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMix
                                         <ThreeDEditorFullscreen
                                             editable
                                             material={globalMaterial}
+                                            // Ignored by wave.js releases that predate the
+                                            // callback; the status bar lights up once available.
+                                            onSelectionChanged={this.onSelectionChanged}
                                             isConventionalCellShown={
                                                 this.props.isConventionalCellShown
                                             }
@@ -310,7 +331,12 @@ class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMix
                                 )}
                             </Grid>
                         </Box>
-                        <EditorSelectionInfo />
+                        <EditorSelectionInfo
+                            material={globalMaterial}
+                            index={mdState.index}
+                            materialsCount={mdState.materials.length}
+                            selectedIndices={this.state.selectedAtomIndices}
+                        />
                     </Paper>
                 </ScopedCssBaseline>
             </ThemeProvider>

--- a/src/MaterialsDesignerContainer.tsx
+++ b/src/MaterialsDesignerContainer.tsx
@@ -19,6 +19,7 @@ import {
     materialsUpdateIndex,
     materialsUpdateNameForOne,
     materialsUpdateOne,
+    stampOriginalSignature,
 } from "./reducers/Material";
 
 // Extend Window interface to include MDState
@@ -108,10 +109,15 @@ export function MaterialsDesignerContainer({
     isLoading = false,
     ...props
 }: MaterialsDesignerContainerProps) {
+    // Stamped once: the materials the session opens with are its baseline, so editing one and
+    // returning it to this state clears the "updated" marker again. Re-stamping on every render
+    // would also mean re-hashing every material on every render.
+    const baselineMaterials = React.useMemo(() => initialMaterials.map(stampOriginalSignature), []);
+
     const [mdState, setMdState, undo, redo, reset] = useUndoableState<MDState>({
         index: 0,
         isLoading: false,
-        materials: initialMaterials,
+        materials: baselineMaterials,
         updatedIndices: [],
     });
 

--- a/src/components/3d_editor_selection_info/EditorSelectionInfo.jsx
+++ b/src/components/3d_editor_selection_info/EditorSelectionInfo.jsx
@@ -11,9 +11,9 @@ import { describeMaterial, describeSelection, SELECTION_HINTS } from "./selectio
 
 export const FOOTER_HEIGHT = 54;
 
-function InfoGroup({ label, children, title }) {
+function InfoGroup({ label, children, title, className }) {
     const content = (
-        <Stack spacing={0.25} sx={{ minWidth: 0 }}>
+        <Stack spacing={0.25} sx={{ minWidth: 0 }} className={className}>
             <Typography
                 variant="caption"
                 sx={{
@@ -47,9 +47,10 @@ InfoGroup.propTypes = {
     label: PropTypes.string.isRequired,
     children: PropTypes.node,
     title: PropTypes.string,
+    className: PropTypes.string,
 };
 
-InfoGroup.defaultProps = { children: null, title: undefined };
+InfoGroup.defaultProps = { children: null, title: undefined, className: undefined };
 
 /**
  * Status bar under the three editor panels: what is selected in the 3D editor, what the active
@@ -76,7 +77,7 @@ const EditorSelectionInfo = function EditorSelectionInfo({
                 overflowX: "auto",
             }}
         >
-            <InfoGroup label="SELECTION" title={selection.tooltip}>
+            <InfoGroup label="SELECTION" title={selection.tooltip} className="status-selection">
                 <Box
                     component="span"
                     sx={{ color: selection.isEmpty ? theme.palette.grey[600] : "primary.light" }}
@@ -85,9 +86,9 @@ const EditorSelectionInfo = function EditorSelectionInfo({
                 </Box>
             </InfoGroup>
             <Divider orientation="vertical" flexItem />
-            <InfoGroup label="MATERIAL">{materialInfo.text}</InfoGroup>
+            <InfoGroup label="MATERIAL" className="status-material">{materialInfo.text}</InfoGroup>
             <Divider orientation="vertical" flexItem />
-            <InfoGroup label="POSITION">
+            <InfoGroup label="POSITION" className="status-position">
                 {materialsCount ? `${index + 1} / ${materialsCount}` : "—"}
             </InfoGroup>
             <Box sx={{ flex: 1 }} />

--- a/src/components/3d_editor_selection_info/EditorSelectionInfo.jsx
+++ b/src/components/3d_editor_selection_info/EditorSelectionInfo.jsx
@@ -1,21 +1,123 @@
 import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
+import Stack from "@mui/material/Stack";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import PropTypes from "prop-types";
 import React from "react";
 
 import { theme } from "../../settings";
+import { describeMaterial, describeSelection, SELECTION_HINTS } from "./selectionInfo";
 
 export const FOOTER_HEIGHT = 54;
 
-const EditorSelectionInfo = function EditorSelectionInfo() {
+function InfoGroup({ label, children, title }) {
+    const content = (
+        <Stack spacing={0.25} sx={{ minWidth: 0 }}>
+            <Typography
+                variant="caption"
+                sx={{
+                    fontSize: "0.6rem",
+                    letterSpacing: "0.08em",
+                    lineHeight: 1,
+                    color: theme.palette.grey[600],
+                }}
+            >
+                {label}
+            </Typography>
+            <Typography
+                variant="body2"
+                sx={{
+                    fontFamily: "monospace",
+                    fontSize: "0.78rem",
+                    lineHeight: 1.2,
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                }}
+            >
+                {children}
+            </Typography>
+        </Stack>
+    );
+    return title ? <Tooltip title={title}>{content}</Tooltip> : content;
+}
+
+InfoGroup.propTypes = {
+    label: PropTypes.string.isRequired,
+    children: PropTypes.node,
+    title: PropTypes.string,
+};
+
+InfoGroup.defaultProps = { children: null, title: undefined };
+
+/**
+ * Status bar under the three editor panels: what is selected in the 3D editor, what the active
+ * material is, and where it sits in the list.
+ */
+const EditorSelectionInfo = function EditorSelectionInfo({
+    material,
+    index,
+    materialsCount,
+    selectedIndices,
+}) {
+    const selection = describeSelection(material, selectedIndices);
+    const materialInfo = describeMaterial(material);
     return (
         <Box
+            id="materials-designer-status-bar"
             sx={{
-                textAlign: "center",
-                padding: 0,
+                display: "flex",
+                alignItems: "center",
+                gap: 2,
+                padding: theme.spacing(0, 2),
                 borderTop: `1px solid ${theme.palette.grey[800]}`,
                 height: `${FOOTER_HEIGHT}px`,
+                overflowX: "auto",
             }}
-        />
+        >
+            <InfoGroup label="SELECTION" title={selection.tooltip}>
+                <Box
+                    component="span"
+                    sx={{ color: selection.isEmpty ? theme.palette.grey[600] : "primary.light" }}
+                >
+                    {selection.text}
+                </Box>
+            </InfoGroup>
+            <Divider orientation="vertical" flexItem />
+            <InfoGroup label="MATERIAL">{materialInfo.text}</InfoGroup>
+            <Divider orientation="vertical" flexItem />
+            <InfoGroup label="POSITION">
+                {materialsCount ? `${index + 1} / ${materialsCount}` : "—"}
+            </InfoGroup>
+            <Box sx={{ flex: 1 }} />
+            <Typography
+                variant="caption"
+                sx={{
+                    color: theme.palette.grey[600],
+                    whiteSpace: "nowrap",
+                    display: { xs: "none", lg: "block" },
+                }}
+            >
+                {SELECTION_HINTS}
+            </Typography>
+        </Box>
     );
+};
+
+EditorSelectionInfo.propTypes = {
+    // eslint-disable-next-line react/forbid-prop-types
+    material: PropTypes.object,
+    index: PropTypes.number,
+    materialsCount: PropTypes.number,
+    selectedIndices: PropTypes.arrayOf(PropTypes.number),
+};
+
+EditorSelectionInfo.defaultProps = {
+    material: undefined,
+    index: 0,
+    materialsCount: 0,
+    selectedIndices: [],
 };
 
 export default EditorSelectionInfo;

--- a/src/components/3d_editor_selection_info/selectionInfo.js
+++ b/src/components/3d_editor_selection_info/selectionInfo.js
@@ -1,0 +1,163 @@
+export const SELECTION_HINTS = "Shift+U / Shift+D switch material";
+
+const SUBSCRIPT_DIGITS = "₀₁₂₃₄₅₆₇₈₉";
+const IMAGE_OFFSETS = [-1, 0, 1];
+
+function toSubscript(number) {
+    return String(number).replace(/\d/g, (d) => SUBSCRIPT_DIGITS[Number(d)]);
+}
+
+function subtract(a, b) {
+    return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+}
+
+function norm(v) {
+    return Math.sqrt(v[0] ** 2 + v[1] ** 2 + v[2] ** 2);
+}
+
+function dot(a, b) {
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+/** Angle in degrees between two displacement vectors sharing an origin atom. */
+function angleBetween(u, v) {
+    const lengths = norm(u) * norm(v);
+    if (!lengths) return null;
+    // Clamp: accumulated float error can push the ratio just outside acos's domain.
+    return (Math.acos(Math.min(1, Math.max(-1, dot(u, v) / lengths))) * 180) / Math.PI;
+}
+
+/** Crystal (fractional) coordinates, read without disturbing the units the session stores. */
+function getCrystalCoordinates(material) {
+    const copy = material.clone();
+    copy.toCrystal();
+    return copy.getBasis().coordinates.map((c) => c.value);
+}
+
+/** Rows of the lattice matrix: `[a, b, c]`, each a cartesian vector in ångström. */
+function getLatticeVectors(material) {
+    const vectors = material.getLattice().vectorArrays;
+    return Array.isArray(vectors) && vectors.length === 3 ? vectors : null;
+}
+
+function crystalToCartesian(fractional, vectors) {
+    return [0, 1, 2].map((axis) =>
+        fractional.reduce((sum, f, vectorIndex) => sum + f * vectors[vectorIndex][axis], 0),
+    );
+}
+
+/**
+ * Cartesian vector from atom `from` to atom `to`, taking the nearest periodic image.
+ *
+ * In a crystal the pair a scientist means is the closest one, which for atoms near opposite faces
+ * of the cell runs through the boundary rather than back across the cell: in a 3.87 Å cell, sites
+ * at 0.0 and 0.9 along `a` are 0.39 Å apart, not 3.48 Å. All 27 neighbouring images are checked
+ * because wrapping fractional offsets alone is not correct for strongly skewed (triclinic) cells.
+ * Non-periodic materials have no images, so their coordinates are used as they are.
+ */
+function displacement(material, coordinates, from, to, vectors) {
+    const delta = subtract(coordinates[to], coordinates[from]);
+    if (material.isNonPeriodic) return crystalToCartesian(delta, vectors);
+
+    let nearest = crystalToCartesian(delta, vectors);
+    let nearestLength = norm(nearest);
+    IMAGE_OFFSETS.forEach((da) =>
+        IMAGE_OFFSETS.forEach((db) =>
+            IMAGE_OFFSETS.forEach((dc) => {
+                const candidate = crystalToCartesian(
+                    [delta[0] + da, delta[1] + db, delta[2] + dc],
+                    vectors,
+                );
+                const length = norm(candidate);
+                if (length < nearestLength) {
+                    nearestLength = length;
+                    nearest = candidate;
+                }
+            }),
+        ),
+    );
+    return nearest;
+}
+
+function labelFor(elements, atomIndex) {
+    return `${elements[atomIndex]?.value ?? "?"}${toSubscript(atomIndex + 1)}`;
+}
+
+/**
+ * Human-readable summary of the atoms selected in the 3D editor: the atom itself for one, the
+ * bond length for two, the angle for three.
+ */
+export function describeSelection(material, selectedIndices) {
+    let elements = [];
+    try {
+        elements = material ? material.getBasis().elements : [];
+    } catch (error) {
+        elements = [];
+    }
+    const indices = (selectedIndices || []).filter(
+        (i) => Number.isInteger(i) && i >= 0 && i < elements.length,
+    );
+    if (!material || indices.length === 0) {
+        return { isEmpty: true, text: "No atoms selected", tooltip: undefined };
+    }
+
+    const labels = indices.map((i) => labelFor(elements, i));
+    try {
+        const coordinates = getCrystalCoordinates(material);
+        if (indices.length === 1) {
+            const [x, y, z] = coordinates[indices[0]];
+            return {
+                isEmpty: false,
+                text: `${labels[0]} @ (${x.toFixed(3)}, ${y.toFixed(3)}, ${z.toFixed(3)})`,
+                tooltip: "Crystal coordinates of the selected atom",
+            };
+        }
+        const vectors = getLatticeVectors(material);
+        if (vectors && indices.length === 2) {
+            const distance = norm(
+                displacement(material, coordinates, indices[0], indices[1], vectors),
+            );
+            return {
+                isEmpty: false,
+                text: `${labels.join("–")} · d = ${distance.toFixed(3)} Å`,
+                tooltip: "Distance to the nearest periodic image of the second atom",
+            };
+        }
+        if (vectors && indices.length === 3) {
+            // Both arms are measured from the middle atom, which is the vertex of the angle.
+            const angle = angleBetween(
+                displacement(material, coordinates, indices[1], indices[0], vectors),
+                displacement(material, coordinates, indices[1], indices[2], vectors),
+            );
+            const angleText = angle === null ? "—" : `${angle.toFixed(1)}°`;
+            return {
+                isEmpty: false,
+                text: `${labels.join("–")} · ∠ = ${angleText}`,
+                tooltip: `Angle at ${labels[1]}, the second atom selected`,
+            };
+        }
+    } catch (error) {
+        // Fall through to the plain count below rather than blanking the whole status bar.
+    }
+    return {
+        isEmpty: false,
+        text: `${indices.length} atoms selected`,
+        tooltip: labels.join(", "),
+    };
+}
+
+/** Formula, atom count and lattice of the active material, for the status bar. */
+export function describeMaterial(material) {
+    if (!material) return { text: "—" };
+    const parts = [];
+    try {
+        if (material.formula) parts.push(material.formula);
+        const atomsCount = material.getBasis().elements.length;
+        if (atomsCount) parts.push(`${atomsCount} ${atomsCount === 1 ? "atom" : "atoms"}`);
+        if (material.lattice?.type) parts.push(material.lattice.type);
+        if (material.isNonPeriodic) parts.push("non-periodic");
+    } catch (error) {
+        // A material that cannot describe itself should not take the status bar down with it.
+    }
+    return { text: parts.length ? parts.join(" · ") : "—" };
+}

--- a/src/components/header_menu/HeaderMenuToolbar.jsx
+++ b/src/components/header_menu/HeaderMenuToolbar.jsx
@@ -36,6 +36,7 @@ import ListItemIcon from "@mui/material/ListItemIcon";
 import MenuItem from "@mui/material/MenuItem";
 import Stack from "@mui/material/Stack";
 import Toolbar from "@mui/material/Toolbar";
+import Tooltip from "@mui/material/Tooltip";
 import setClass from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
@@ -324,9 +325,13 @@ class HeaderMenuToolbar extends React.Component {
         return (
             <Stack spacing={2} direction="row" justifyContent="end" sx={{ flex: 1 }}>
                 {mdState.isLoading ? (
-                    <CircularProgress color="warning" size={30} />
+                    <Tooltip title="Working…">
+                        <CircularProgress color="warning" size={30} />
+                    </Tooltip>
                 ) : (
-                    <CheckIcon color="success" size={50} />
+                    <Tooltip title="All changes applied">
+                        <CheckIcon color="success" size={50} />
+                    </Tooltip>
                 )}
             </Stack>
         );

--- a/src/components/items_list/ItemsList.jsx
+++ b/src/components/items_list/ItemsList.jsx
@@ -9,6 +9,7 @@ import ListItemAvatar from "@mui/material/ListItemAvatar";
 import ListItemText from "@mui/material/ListItemText";
 import Paper from "@mui/material/Paper";
 import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import setClass from "classnames";
 import PropTypes from "prop-types";
@@ -124,15 +125,18 @@ class ItemsList extends React.Component {
                         { updated: isUpdated || isBeingEdited },
                     )}
                     secondaryAction={
-                        <IconButton
-                            edge="end"
-                            className="list-item-icon icon-button-delete"
-                            onClick={(e) => {
-                                this.onDeleteIconClick(e, index);
-                            }}
-                        >
-                            <DeleteIcon sx={{ color: neutralColor }} />
-                        </IconButton>
+                        <Tooltip title={`Remove "${name}"`}>
+                            <IconButton
+                                edge="end"
+                                aria-label={`Remove ${name}`}
+                                className="list-item-icon icon-button-delete"
+                                onClick={(e) => {
+                                    this.onDeleteIconClick(e, index);
+                                }}
+                            >
+                                <DeleteIcon sx={{ color: neutralColor }} />
+                            </IconButton>
+                        </Tooltip>
                     }
                     sx={{
                         // TODO: figure out why "dense" prop doesn't work and remove this

--- a/src/reducers/InputOutput.ts
+++ b/src/reducers/InputOutput.ts
@@ -22,6 +22,8 @@ export function materialsAdd(
               .concat(state.materials.slice(index + 1))
         : state.materials.concat(actionMaterials);
     const addedIndices = indicesForAddedMaterials(state, actionMaterials.length, action.addAtIndex);
+    // Materials arriving from outside the session (import, upload, transformation output) carry no
+    // original signature, so they stay flagged as updated until saved.
     return addUpdatedIndices({ ...state, materials: newMaterials }, addedIndices);
 }
 

--- a/src/reducers/Material.ts
+++ b/src/reducers/Material.ts
@@ -16,10 +16,46 @@ export type MDState = {
     updatedIndices: number[];
 };
 
+/**
+ * Identity of a material for "has this been edited?" purposes. `hash` covers only basis and
+ * lattice, so name and boundary conditions - both editable in the app - are folded in explicitly.
+ * Returns `null` for materials that cannot be hashed (unsupported lattice/basis), which are then
+ * treated as always-updated rather than silently reported as unchanged.
+ */
+export function getMaterialSignature(material: MDMaterial): string | null {
+    try {
+        const boundaryConditions = JSON.stringify(material.boundaryConditions || {});
+        return `${material.hash}:${material.name}:${boundaryConditions}`;
+    } catch (error) {
+        return null;
+    }
+}
+
+/** Records where a material starts from, so a later edit can be recognised as reverted. */
+export function stampOriginalSignature<T extends MDMaterial>(material: T): T {
+    const signature = getMaterialSignature(material);
+    if (signature) material.originalSignature = signature;
+    return material;
+}
+
 export function addUpdatedIndices(state: MDState, indices: number[]): MDState {
     const updated = new Set(state.updatedIndices);
     indices.forEach((i) => updated.add(i));
     return { ...state, updatedIndices: [...updated] };
+}
+
+/**
+ * Flags `index` as updated, or clears the flag when the material is byte-identical to the version
+ * that entered the session — so undoing an edit by hand also clears the "updated" marker.
+ */
+export function syncUpdatedIndexBySignature(state: MDState, index: number): MDState {
+    const material = state.materials[index];
+    const { originalSignature } = material;
+    // No recorded original (created in-session) means there is nothing to revert to: stay flagged.
+    const isBackToOriginal =
+        Boolean(originalSignature) && getMaterialSignature(material) === originalSignature;
+    if (!isBackToOriginal) return addUpdatedIndices(state, [index]);
+    return { ...state, updatedIndices: state.updatedIndices.filter((i) => i !== index) };
 }
 
 export function isMaterialUpdated(state: MDState, index: number): boolean {
@@ -71,7 +107,7 @@ export function materialsUpdateOne(
     const material = action.material.clone(); // clone material to assert props re-render
     // TODO: consider adjusting the logic to avoid expensive cloning procedure below
     materials[index] = material;
-    return addUpdatedIndices({ ...state, materials }, [index]);
+    return syncUpdatedIndexBySignature({ ...state, materials }, index);
 }
 
 export function materialsCloneOne(state: MDState): MDState {
@@ -80,6 +116,8 @@ export function materialsCloneOne(state: MDState): MDState {
     material.cleanOnCopy();
     material.name = "New Material";
     materials.push(material);
+    // `cleanOnCopy` drops the original signature: a clone has no saved counterpart, so it stays
+    // flagged as updated regardless of later edits.
     return addUpdatedIndices({ ...state, materials }, [materials.length - 1]);
 }
 

--- a/tests/cypress/e2e/materials-list/updated-marker.feature
+++ b/tests/cypress/e2e/materials-list/updated-marker.feature
@@ -1,0 +1,35 @@
+Feature: A material is flagged as updated only while it differs from how it entered the session
+
+  # README TODO: "switch the color back to white when the material is back to the original after
+  # editing". The flag drives the marker on the list row.
+
+  Scenario: Editing the basis flags the material, and putting it back clears the flag
+    When I open materials designer page
+    Then I see material designer page
+    And material with index "1" is not marked as updated
+
+    When I set material basis and lattice with the following data:
+      | basis                              |
+      | Si 0 0 0;Si 0.3 0.3 0.3            |
+    Then material with index "1" is marked as updated
+
+    # Byte-identical to the material the session opened with
+    When I set material basis and lattice with the following data:
+      | basis                                |
+      | Si 0 0 0;Si 0.25 0.25 0.25           |
+    Then material with index "1" is not marked as updated
+
+  Scenario: A clone has no original to return to, so it stays flagged
+    When I open materials designer page
+    Then I see material designer page
+    When I clone material at index "1"
+    Then material with index "2" is marked as updated
+
+    # Editing it and undoing that edit by hand must not make it look saved
+    When I set material basis and lattice with the following data:
+      | basis                              |
+      | Si 0 0 0;Si 0.3 0.3 0.3            |
+    And I set material basis and lattice with the following data:
+      | basis                                |
+      | Si 0 0 0;Si 0.25 0.25 0.25           |
+    Then material with index "2" is marked as updated

--- a/tests/cypress/e2e/status-bar/status-bar.feature
+++ b/tests/cypress/e2e/status-bar/status-bar.feature
@@ -1,0 +1,29 @@
+Feature: The status bar describes the active material and where it sits in the list
+
+  Scenario: Status bar reports the material and its position, and follows the selection
+    When I open materials designer page
+    Then I see material designer page
+    And I see status bar showing
+      | group     | text              |
+      | material  | Si                |
+      | material  | 2 atoms           |
+      | material  | FCC               |
+      | position  | 1 / 1             |
+      | selection | No atoms selected |
+
+    # Cloning appends without switching to the copy: the denominator grows, the numerator does not
+    When I clone material at index "1"
+    Then I see status bar showing
+      | group    | text  |
+      | position | 1 / 2 |
+
+    # Selecting the copy moves the numerator
+    When I select material with index "2" from material designer items list
+    Then I see status bar showing
+      | group    | text  |
+      | position | 2 / 2 |
+
+    When I select material with index "1" from material designer items list
+    Then I see status bar showing
+      | group    | text  |
+      | position | 1 / 2 |

--- a/tests/cypress/support/step_definitions/I see status bar showing.ts
+++ b/tests/cypress/support/step_definitions/I see status bar showing.ts
@@ -1,0 +1,28 @@
+import { DataTable, Given } from "@badeball/cypress-cucumber-preprocessor";
+import { parseTable } from "@mat3ra/tede/src/js/cypress/utils/table";
+
+import { StatusBarWidget } from "../widgets/StatusBarWidget";
+
+interface Params {
+    group: "selection" | "material" | "position";
+    text: string;
+}
+
+const readers = {
+    selection: (widget: StatusBarWidget) => widget.getSelectionText(),
+    material: (widget: StatusBarWidget) => widget.getMaterialText(),
+    position: (widget: StatusBarWidget) => widget.getPositionText(),
+};
+
+/**
+ * Asserts a status bar group contains the given text. Substring rather than equality: the groups
+ * render a label above the value, and the value itself grows as more facts become available.
+ */
+Given("I see status bar showing", (table: DataTable) => {
+    const widget = new StatusBarWidget();
+    parseTable<Params>(table).forEach(({ group, text }) => {
+        const read = readers[group];
+        if (!read) throw new Error(`Unknown status bar group "${group}"`);
+        read(widget).should("contain", text);
+    });
+});

--- a/tests/cypress/support/step_definitions/I set material basis and lattice with the following data.ts
+++ b/tests/cypress/support/step_definitions/I set material basis and lattice with the following data.ts
@@ -12,6 +12,8 @@ Given("I set material basis and lattice with the following data:", (table: DataT
     const { basis, lattice } = parseTable<BasisAndLatice>(table)[0];
     const { basisEditor, latticeEditor } = new MaterialDesignerPage().designerWidget.sourceEditor;
 
-    basisEditor.setBasis(basis);
-    latticeEditor.setLattice(JSON.parse(lattice));
+    // Either column on its own is useful: a scenario about the basis should not have to restate a
+    // lattice it does not care about.
+    if (basis) basisEditor.setBasis(basis);
+    if (lattice) latticeEditor.setLattice(JSON.parse(lattice));
 });

--- a/tests/cypress/support/step_definitions/material with index is marked as updated.ts
+++ b/tests/cypress/support/step_definitions/material with index is marked as updated.ts
@@ -1,0 +1,20 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+import BrowserManager from "@mat3ra/tede/src/js/cypress/BrowserManager";
+
+/**
+ * The "updated" flag lives in `MDState.updatedIndices` and drives the marker on the list row.
+ * Asserting on the state rather than the styling keeps the check about behaviour, not appearance.
+ */
+function getUpdatedIndices() {
+    return BrowserManager.getBrowser().execute((win) => {
+        return win.MDState.updatedIndices;
+    });
+}
+
+Given("material with index {string} is marked as updated", (index: string) => {
+    getUpdatedIndices().should("include", parseInt(index, 10) - 1);
+});
+
+Given("material with index {string} is not marked as updated", (index: string) => {
+    getUpdatedIndices().should("not.include", parseInt(index, 10) - 1);
+});

--- a/tests/cypress/support/widgets/StatusBarWidget.ts
+++ b/tests/cypress/support/widgets/StatusBarWidget.ts
@@ -1,0 +1,31 @@
+import Widget from "./Widget";
+
+const selectors = {
+    wrapper: "#materials-designer-status-bar",
+    selection: "#materials-designer-status-bar .status-selection",
+    material: "#materials-designer-status-bar .status-material",
+    position: "#materials-designer-status-bar .status-position",
+};
+
+export class StatusBarWidget extends Widget {
+    selectors: typeof selectors;
+
+    constructor() {
+        super(selectors.wrapper);
+        this.selectors = selectors;
+    }
+
+    getSelectionText() {
+        return this.browser.getElementText(this.selectors.selection);
+    }
+
+    getMaterialText() {
+        return this.browser.getElementText(this.selectors.material);
+    }
+
+    getPositionText() {
+        return this.browser.getElementText(this.selectors.position);
+    }
+}
+
+export default StatusBarWidget;


### PR DESCRIPTION
First of a chain of UI/UX PRs (see `UIUX_IMPROVEMENTS.md` on `claude/uiux-improvements-brainstorm-ao5wcf` for the scored plan). Opened as a draft for review of direction before the rest land on top.

## What

The footer reserved 54 px for selection info that never shipped — `EditorSelectionInfo` rendered an empty `Box`. It now carries the three things you otherwise have to hunt for:

| Group | Shows |
| --- | --- |
| SELECTION | coordinates for one atom · distance for two · angle for three |
| MATERIAL | formula · atom count · lattice type (+ `non-periodic`) |
| POSITION | `n / N` in the materials list |

Plus a revert-aware "updated" marker and tooltips on the previously unlabeled icon buttons.

## Notable decisions

**Distances use the nearest periodic image.** For atoms near opposite faces of the cell, the pair a scientist means is the one bonded through the boundary. In the default 3.87 Å Si cell, sites at 0.0 and 0.9 along `a` now report **0.387 Å** rather than the 3.48 Å way back across the cell. All 27 neighbouring images are checked, because wrapping fractional offsets alone is wrong for strongly skewed (triclinic) cells. Non-periodic materials are measured as-is.

**Selection arrives from wave.js, forward-compatibly.** `onSelectionChanged` is passed to `ThreeDEditor` now; the pinned `2026.8.13-0` build does not emit it (verified against the published tarball), so it is inert today and the readout lights up on the next wave upgrade with no further MD change. Wave HEAD documents this callback as "the data source for a host's selection-info UI". The footer stays complementary to wave's in-canvas inspector rather than duplicating it: material/list context here, per-atom detail there.

**"Updated" now clears when a material is edited back to how it arrived** (README TODO). The comparison signature folds in name and boundary conditions, because made's `hash` covers only basis and lattice — without that, setting boundary conditions would silently *clear* the marker.

**Carried on the material, not in a parallel array.** `MDMaterial.originalSignature` is ephemeral, preserved across `clone()` and absent from `toJSON()` — deliberately the same shape as `syncScope` on `feature/SOF-7961`, so the two compose. An index-keyed side array would have desynced the moment `materialsSyncScope` rebuilds the materials list. Expect a one-line conflict in `MDMaterial.clone()` when these merge; keep both assignments.

## Verified

Driven against the running app (Playwright), not only reasoned about:

- selection readout across 0 / 1 / 2 / 3 atoms, and reset when the active material changes
- `2.368 Å` for the Si–Si bonded pair (correct nearest-neighbour distance), `0.387 Å` across the boundary
- updated-marker matrix: edit → flagged, revert → cleared, rename → flagged, un-rename → cleared, boundary conditions → flagged, clone → stays flagged, import → flagged, remove → indices adjusted
- `tsc --noEmit` and `eslint src` clean (3 pre-existing warnings in `BaseJupyterLiteComponent` untouched)
- no console errors on load

Cypress selectors are untouched: menu item ordering and the `ul>div:nth-of-type(N) li` list structure the widgets depend on are unchanged.

## Closes

Two README §2.2 TODOs, removed in this PR: *"switch the color back to white when the material is back to the original after editing"* and *"show the total number of materials in the list and the current index"*.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tg648kyhgbSwikBzhSjvXg)_