### PR TITLE
feat(materials-list): count, filter, add menu and undoable removal

### DIFF
--- a/src/MaterialsDesigner.jsx
+++ b/src/MaterialsDesigner.jsx
@@ -22,6 +22,8 @@ import EditorSelectionInfo, {
 } from "./components/3d_editor_selection_info/EditorSelectionInfo";
 import JupyterLiteSessionDrawer from "./components/drawer_session/JupyterLiteSessionDrawer";
 import HeaderMenuToolbar from "./components/header_menu/HeaderMenuToolbar";
+import StandataImportDialog from "./components/include/StandataImportDialog";
+import UploadDialog from "./components/include/UploadDialog";
 import ItemsList from "./components/items_list/ItemsList";
 import BasisEditor from "./components/source_editor/Basis";
 import LatticeEditor from "./components/source_editor/Lattice";
@@ -82,6 +84,8 @@ class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMix
             isVisibleJupyterLiteSessionDrawer: false,
             importMaterialsDialogProps: null,
             selectedAtomIndices: [],
+            // Owned here rather than in the header menu: the materials list opens these too.
+            openDialog: null,
         };
         this.containerRef = React.createRef();
     }
@@ -141,6 +145,15 @@ class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMix
         this.setState({ selectedAtomIndices: selectedAtomIndices || [] });
     };
 
+    onOpenDialog = (openDialog) => this.setState({ openDialog });
+
+    onCloseDialog = () => this.setState({ openDialog: null });
+
+    onAddFromDialog = (...args) => {
+        this.props.onAdd(...args);
+        this.onCloseDialog();
+    };
+
     onSectionVisibilityToggle = (componentName) => {
         const stateKey = `isVisible${componentName}`;
         if (stateKey in this.state) {
@@ -191,6 +204,7 @@ class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMix
                                 maxCombinatorialBasesCount={this.props.maxCombinatorialBasesCount}
                                 defaultMaterialsSet={this.props.defaultMaterialsSet}
                                 onSectionVisibilityToggle={this.onSectionVisibilityToggle}
+                                onOpenDialog={this.onOpenDialog}
                                 isVisibleItemsList={isVisibleItemsList}
                                 isVisibleSourceEditor={isVisibleSourceEditor}
                                 isVisibleThreeDEditorFullscreen={isVisibleThreeDEditorFullscreen}
@@ -258,7 +272,11 @@ class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMix
                                                 updatedIndices={mdState.updatedIndices}
                                                 onItemClick={this.props.onItemClick}
                                                 onRemove={this.props.onRemove}
+                                                onRestore={this.props.onRestore}
                                                 onNameUpdate={this.props.onNameUpdate}
+                                                onClone={this.props.onClone}
+                                                onImport={() => this.onOpenDialog("standata")}
+                                                onUpload={() => this.onOpenDialog("upload")}
                                             />
                                         </Grid>
                                     </Grid>
@@ -337,6 +355,20 @@ class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMix
                             materialsCount={mdState.materials.length}
                             selectedIndices={this.state.selectedAtomIndices}
                         />
+
+                        <StandataImportDialog
+                            modalId="standataImportModalDialog"
+                            show={this.state.openDialog === "standata"}
+                            onSubmit={this.onAddFromDialog}
+                            onClose={this.onCloseDialog}
+                            defaultMaterialConfigs={this.props.defaultMaterialsSet}
+                        />
+
+                        <UploadDialog
+                            show={this.state.openDialog === "upload"}
+                            onClose={this.onCloseDialog}
+                            onSubmit={this.onAddFromDialog}
+                        />
                     </Paper>
                 </ScopedCssBaseline>
             </ThemeProvider>
@@ -382,6 +414,7 @@ MaterialsDesigner.propTypes = {
     openSaveActionDialog: PropTypes.func,
 
     onRemove: PropTypes.func,
+    onRestore: PropTypes.func,
 
     maxCombinatorialBasesCount: PropTypes.number,
     // eslint-disable-next-line react/forbid-prop-types

--- a/src/MaterialsDesignerContainer.tsx
+++ b/src/MaterialsDesignerContainer.tsx
@@ -6,7 +6,12 @@ import React, { useCallback, useEffect, useState } from "react";
 
 import MaterialsDesignerComponent from "./MaterialsDesigner";
 import { MDMaterial } from "./MDMaterial";
-import { materialsAdd, materialsExport, materialsRemove } from "./reducers/InputOutput";
+import {
+    materialsAdd,
+    materialsExport,
+    materialsInsertAt,
+    materialsRemove,
+} from "./reducers/InputOutput";
 import {
     type BoundaryConditionsType,
     type MDState,
@@ -168,6 +173,10 @@ export function MaterialsDesignerContainer({
         setMdState(materialsRemove(mdState.current, { index }));
     }, []);
 
+    const onRestore = useCallback((material: MDMaterial, index: number) => {
+        setMdState(materialsInsertAt(mdState.current, { material, index }));
+    }, []);
+
     const onExport = useCallback((format: "json" | "poscar", useMultiple: boolean) => {
         setMdState(materialsExport(mdState.current, { format, useMultiple }));
     }, []);
@@ -189,6 +198,7 @@ export function MaterialsDesignerContainer({
             onSetBoundaryConditions={onSetBoundaryConditions}
             onAdd={onAdd}
             onRemove={onRemove}
+            onRestore={onRestore}
             onExport={onExport}
             {...props}
         />

--- a/src/components/header_menu/HeaderMenuToolbar.jsx
+++ b/src/components/header_menu/HeaderMenuToolbar.jsx
@@ -50,8 +50,6 @@ import JupyterLiteTransformation from "../3d_editor/advanced_geometry/python_tra
 import SupercellDialog from "../3d_editor/advanced_geometry/SupercellDialog";
 import SurfaceDialog from "../3d_editor/advanced_geometry/SurfaceDialog";
 import { ButtonActivatedMenuMaterialUI } from "../include/material-ui/ButtonActivatedMenu";
-import StandataImportDialog from "../include/StandataImportDialog";
-import UploadDialog from "../include/UploadDialog";
 import ExportActionDialog from "./ExportActionDialog";
 
 class HeaderMenuToolbar extends React.Component {
@@ -61,8 +59,6 @@ class HeaderMenuToolbar extends React.Component {
             showSupercellDialog: false,
             showSurfaceDialog: false,
             showExportMaterialsDialog: false,
-            showStandataImportDialog: false,
-            showDefaultImportModalDialog: false,
             showCombinatorialDialog: false,
             showInterpolateDialog: false,
             // TODO: unused while renderThreejsEditorModal is disabled, see comment
@@ -92,13 +88,13 @@ class HeaderMenuToolbar extends React.Component {
                     </ListItemIcon>
                     Import
                 </MenuItem>
-                <MenuItem onClick={() => this.setState({ showStandataImportDialog: true })}>
+                <MenuItem onClick={() => this.props.onOpenDialog("standata")}>
                     <ListItemIcon>
                         <AddCircleIcon />
                     </ListItemIcon>
                     Import from Standata
                 </MenuItem>
-                <MenuItem onClick={() => this.setState({ showDefaultImportModalDialog: true })}>
+                <MenuItem onClick={() => this.props.onOpenDialog("upload")}>
                     <ListItemIcon>
                         <IconByName name="actions.upload" />
                     </ListItemIcon>
@@ -394,8 +390,6 @@ class HeaderMenuToolbar extends React.Component {
             showCombinatorialDialog,
             showExportMaterialsDialog,
             showInterpolateDialog,
-            showStandataImportDialog,
-            showDefaultImportModalDialog,
             showJupyterLiteTransformation,
         } = this.state;
         const {
@@ -408,7 +402,6 @@ class HeaderMenuToolbar extends React.Component {
             onGenerateSurface,
             onSetBoundaryConditions,
             maxCombinatorialBasesCount,
-            defaultMaterialsSet,
         } = this.props;
 
         const material = materials[index];
@@ -461,25 +454,8 @@ class HeaderMenuToolbar extends React.Component {
                     onSubmit={onExport}
                 />
 
-                <StandataImportDialog
-                    modalId="standataImportModalDialog"
-                    show={showStandataImportDialog}
-                    onSubmit={(...args) => {
-                        onAdd(...args);
-                        this.setState({ showStandataImportDialog: false });
-                    }}
-                    onClose={() => this.setState({ showStandataImportDialog: false })}
-                    defaultMaterialConfigs={defaultMaterialsSet}
-                />
-
-                <UploadDialog
-                    show={showDefaultImportModalDialog}
-                    onClose={() => this.setState({ showDefaultImportModalDialog: false })}
-                    onSubmit={(...args) => {
-                        onAdd(...args);
-                        this.setState({ showDefaultImportModalDialog: false });
-                    }}
-                />
+                {/* The Standata and upload dialogs are owned by MaterialsDesigner: the materials
+                    list opens them too, from its "add material" menu. */}
 
                 <CombinatorialBasisDialog
                     title="Generate Combinatorial Set"
@@ -551,6 +527,8 @@ HeaderMenuToolbar.propTypes = {
     onGenerateSurface: PropTypes.func.isRequired,
     onSetBoundaryConditions: PropTypes.func.isRequired,
     onSectionVisibilityToggle: PropTypes.func.isRequired,
+    /** Opens a dialog owned by MaterialsDesigner: "standata" or "upload". */
+    onOpenDialog: PropTypes.func.isRequired,
     isVisibleItemsList: PropTypes.bool.isRequired,
     isVisibleSourceEditor: PropTypes.bool.isRequired,
     isVisibleThreeDEditorFullscreen: PropTypes.bool.isRequired,

--- a/src/components/items_list/ItemsList.jsx
+++ b/src/components/items_list/ItemsList.jsx
@@ -2,6 +2,8 @@ import IconByName from "@mat3ra/cove/dist/mui/components/icon/IconByName";
 import DeleteIcon from "@mui/icons-material/Delete";
 import Avatar from "@mui/material/Avatar";
 import Badge from "@mui/material/Badge";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
@@ -12,10 +14,25 @@ import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import setClass from "classnames";
+import { closeSnackbar, enqueueSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React from "react";
 
 import { theme } from "../../settings";
+import ItemsListHeader, { buildAddActions } from "./ItemsListHeader";
+
+/** Short structural facts for a list row: lattice type and site count. */
+function describeStructure(material) {
+    const facts = [];
+    try {
+        if (material.lattice?.type) facts.push(material.lattice.type);
+        const sites = material.getBasis().elements.length;
+        if (sites) facts.push(`${sites} ${sites === 1 ? "site" : "sites"}`);
+    } catch (error) {
+        // A material that cannot describe itself still gets a row, just a plainer one.
+    }
+    return facts;
+}
 
 class ItemsList extends React.Component {
     constructor(props) {
@@ -32,7 +49,24 @@ class ItemsList extends React.Component {
         return {
             editedName: materials[index].name,
             editedIndex: -1,
+            filter: "",
         };
+    }
+
+    /** Materials matching the filter, each keeping the index it has in the unfiltered list. */
+    get visibleEntries() {
+        const { materials } = this.props;
+        const { filter } = this.state;
+        const query = filter.trim().toLowerCase();
+        const entries = materials.map((material, index) => ({ material, index }));
+        if (!query) return entries;
+        return entries.filter(({ material }) =>
+            [material.name, material.formula].some((value) =>
+                String(value || "")
+                    .toLowerCase()
+                    .includes(query),
+            ),
+        );
     }
 
     componentDidUpdate(prevProps) {
@@ -86,9 +120,36 @@ class ItemsList extends React.Component {
      */
     // eslint-disable-next-line react/sort-comp
     onDeleteIconClick(e, index) {
-        const { onRemove } = this.props;
+        const { materials, onRemove, onRestore } = this.props;
         e.preventDefault();
+        // Captured before the removal so the offer to undo restores this exact material - including
+        // its original signature - at the position it came from.
+        const removed = materials[index];
+        const canRestore = materials.length > 1 && Boolean(onRestore);
         onRemove(index);
+        if (!canRestore) return;
+        // The undo control lives in the message rather than notistack's `action` slot: cove's
+        // AlertProvider supplies its own Snackbar component for every variant, and that component
+        // renders only the message.
+        const snackbarKey = `undo-remove-${removed.name}-${index}`;
+        enqueueSnackbar(
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <span>Removed “{removed.name}”</span>
+                <Button
+                    size="small"
+                    variant="outlined"
+                    color="inherit"
+                    className="undo-remove-material"
+                    onClick={() => {
+                        onRestore(removed, index);
+                        closeSnackbar(snackbarKey);
+                    }}
+                >
+                    Undo
+                </Button>
+            </Box>,
+            { variant: "default", key: snackbarKey },
+        );
     }
 
     /**
@@ -210,8 +271,40 @@ class ItemsList extends React.Component {
                         }
                         secondary={
                             // TODO: avoid setting font size in sx and use theme variants instead
-                            <Typography variant="caption" sx={{ fontSize: "0.8em" }}>
-                                Formula: <code>{entity.formula}</code>
+                            <Typography
+                                variant="caption"
+                                component="span"
+                                sx={{
+                                    fontSize: "0.8em",
+                                    display: "flex",
+                                    alignItems: "center",
+                                    gap: 0.75,
+                                }}
+                            >
+                                <code>{entity.formula}</code>
+                                {describeStructure(entity).map((fact) => (
+                                    <Box
+                                        key={fact}
+                                        component="span"
+                                        sx={{ color: theme.palette.grey[600] }}
+                                    >
+                                        {fact}
+                                    </Box>
+                                ))}
+                                {isUpdated && (
+                                    <Tooltip title="Edited since it entered the session">
+                                        <Box
+                                            component="span"
+                                            className="material-updated-dot"
+                                            sx={{
+                                                width: 6,
+                                                height: 6,
+                                                borderRadius: "50%",
+                                                backgroundColor: "warning.main",
+                                            }}
+                                        />
+                                    </Tooltip>
+                                )}
                             </Typography>
                         }
                     />
@@ -221,16 +314,37 @@ class ItemsList extends React.Component {
     }
 
     render() {
-        const { materials, index, updatedIndices } = this.props;
+        const { materials, index, updatedIndices, onClone, onImport, onUpload } = this.props;
+        const { filter } = this.state;
+        const entries = this.visibleEntries;
         return (
-            <List
-                sx={{
-                    // TODO: figure out why "dense" prop doesn't work and remove this
-                    paddingY: 0,
-                }}
-            >
-                {materials.map((m, i) => this.renderListItem(m, i, index, updatedIndices))}
-            </List>
+            <>
+                <ItemsListHeader
+                    filter={filter}
+                    onFilterChange={(value) => this.setState({ filter: value })}
+                    shownCount={entries.length}
+                    totalCount={materials.length}
+                    addActions={buildAddActions({ onClone, onImport, onUpload })}
+                />
+                <List
+                    sx={{
+                        // TODO: figure out why "dense" prop doesn't work and remove this
+                        paddingY: 0,
+                    }}
+                >
+                    {entries.map(({ material, index: materialIndex }) =>
+                        this.renderListItem(material, materialIndex, index, updatedIndices),
+                    )}
+                </List>
+                {entries.length === 0 && (
+                    <Typography
+                        variant="body2"
+                        sx={{ p: 2, textAlign: "center", color: theme.palette.grey[600] }}
+                    >
+                        No materials match “{filter}”.
+                    </Typography>
+                )}
+            </>
         );
     }
 }
@@ -243,6 +357,15 @@ ItemsList.propTypes = {
     onItemClick: PropTypes.func.isRequired,
     onRemove: PropTypes.func.isRequired,
     onNameUpdate: PropTypes.func.isRequired,
+    /** Puts a removed material back; without it, removal is not offered as undoable. */
+    onRestore: PropTypes.func,
+    onClone: PropTypes.func.isRequired,
+    onImport: PropTypes.func.isRequired,
+    onUpload: PropTypes.func.isRequired,
+};
+
+ItemsList.defaultProps = {
+    onRestore: undefined,
 };
 
 export default ItemsList;

--- a/src/components/items_list/ItemsList.jsx
+++ b/src/components/items_list/ItemsList.jsx
@@ -339,6 +339,7 @@ class ItemsList extends React.Component {
                 {entries.length === 0 && (
                     <Typography
                         variant="body2"
+                        className="materials-empty-state"
                         sx={{ p: 2, textAlign: "center", color: theme.palette.grey[600] }}
                     >
                         No materials match “{filter}”.

--- a/src/components/items_list/ItemsListHeader.jsx
+++ b/src/components/items_list/ItemsListHeader.jsx
@@ -1,0 +1,113 @@
+import Dropdown from "@mat3ra/cove/dist/mui/components/dropdown/Dropdown";
+import IconByName from "@mat3ra/cove/dist/mui/components/icon/IconByName";
+import AddIcon from "@mui/icons-material/Add";
+import CloneIcon from "@mui/icons-material/Collections";
+import SearchIcon from "@mui/icons-material/Search";
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import IconButton from "@mui/material/IconButton";
+import InputAdornment from "@mui/material/InputAdornment";
+import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import PropTypes from "prop-types";
+import React from "react";
+
+import { theme } from "../../settings";
+
+/**
+ * Title, count, filter and the "add material" menu. Deliberately rendered outside the list's `ul`:
+ * the Cypress widgets address items as `ul > div:nth-of-type(N) li`.
+ */
+function ItemsListHeader({ filter, onFilterChange, shownCount, totalCount, addActions }) {
+    return (
+        <Box
+            className="materials-designer-items-list-header"
+            sx={{
+                padding: theme.spacing(1, 1.25, 1),
+                borderBottom: `1px solid ${theme.palette.grey[800]}`,
+            }}
+        >
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.75 }}>
+                <Typography
+                    variant="caption"
+                    sx={{ letterSpacing: "0.08em", color: theme.palette.grey[500] }}
+                >
+                    MATERIALS
+                </Typography>
+                <Chip
+                    size="small"
+                    className="materials-count"
+                    label={filter ? `${shownCount} / ${totalCount}` : totalCount}
+                    sx={{ height: 18, fontSize: "0.7rem" }}
+                />
+                <Box sx={{ flex: 1 }} />
+                <Dropdown
+                    id="add-material-menu"
+                    className="add-material-menu"
+                    actions={addActions}
+                    popperProps={{ id: "add-material-popper" }}
+                >
+                    <Tooltip title="Add a material">
+                        <IconButton size="small" aria-label="Add a material">
+                            <AddIcon fontSize="small" />
+                        </IconButton>
+                    </Tooltip>
+                </Dropdown>
+            </Box>
+            <TextField
+                fullWidth
+                size="small"
+                variant="outlined"
+                className="materials-filter"
+                placeholder="Filter by name or formula"
+                value={filter}
+                onChange={(event) => onFilterChange(event.target.value)}
+                inputProps={{ "aria-label": "Filter materials" }}
+                InputProps={{
+                    startAdornment: (
+                        <InputAdornment position="start">
+                            <SearchIcon sx={{ fontSize: "1rem", color: theme.palette.grey[600] }} />
+                        </InputAdornment>
+                    ),
+                    sx: { fontSize: "0.8rem" },
+                }}
+            />
+        </Box>
+    );
+}
+
+ItemsListHeader.propTypes = {
+    filter: PropTypes.string.isRequired,
+    onFilterChange: PropTypes.func.isRequired,
+    shownCount: PropTypes.number.isRequired,
+    totalCount: PropTypes.number.isRequired,
+    // eslint-disable-next-line react/forbid-prop-types
+    addActions: PropTypes.array.isRequired,
+};
+
+/** Actions for the "+" menu, in the shape cove's Dropdown expects. */
+export function buildAddActions({ onClone, onImport, onUpload }) {
+    return [
+        {
+            id: "clone-active-material",
+            content: "Clone active material",
+            icon: <CloneIcon fontSize="small" />,
+            onClick: onClone,
+        },
+        {
+            id: "import-from-standata",
+            content: "Import from Standata",
+            icon: <IconByName name="actions.download" fontSize="small" />,
+            onClick: onImport,
+        },
+        {
+            id: "upload-from-disk",
+            content: "Upload from disk",
+            icon: <IconByName name="actions.upload" fontSize="small" />,
+            onClick: onUpload,
+        },
+    ];
+}
+
+export default ItemsListHeader;

--- a/src/reducers/InputOutput.ts
+++ b/src/reducers/InputOutput.ts
@@ -1,4 +1,4 @@
-import { showSuccessAlert, showWarningAlert } from "@mat3ra/cove/dist/other/alerts";
+import { showWarningAlert } from "@mat3ra/cove/dist/other/alerts";
 import type { MDMaterial } from "src/MDMaterial";
 
 import { exportToDisk } from "../utils/downloader";
@@ -7,6 +7,8 @@ import {
     addUpdatedIndices,
     adjustUpdatedIndicesForRemove,
     indicesForAddedMaterials,
+    isMaterialUpdated,
+    syncUpdatedIndexBySignature,
 } from "./Material";
 
 export function materialsAdd(
@@ -50,11 +52,32 @@ export function materialsRemove(state: MDState, action: { index: number }): MDSt
         return state;
     }
 
-    showSuccessAlert(`Removed material at index ${indexToRemove}.`);
+    // The removal is announced by the caller, which can offer to undo it.
     return adjustUpdatedIndicesForRemove(
         { ...state, materials: newMaterials, index: newIndex },
         indexToRemove,
     );
+}
+
+/**
+ * Puts a removed material back where it was, keeping it selected. The material object carries its
+ * own original signature, so restoring does not make an unedited material look edited.
+ */
+export function materialsInsertAt(
+    state: MDState,
+    action: { material: MDMaterial; index: number },
+): MDState {
+    const index = Math.max(0, Math.min(action.index, state.materials.length));
+    const materials = [
+        ...state.materials.slice(0, index),
+        action.material,
+        ...state.materials.slice(index),
+    ];
+    const updatedIndices = state.updatedIndices.map((i) => (i >= index ? i + 1 : i));
+    const restored = { ...state, materials, updatedIndices, index };
+    return isMaterialUpdated(restored, index)
+        ? restored
+        : syncUpdatedIndexBySignature(restored, index);
 }
 
 export function materialsExport(

--- a/tests/cypress/e2e/materials-list/filter-and-count.feature
+++ b/tests/cypress/e2e/materials-list/filter-and-count.feature
@@ -1,0 +1,49 @@
+Feature: The materials list can be counted, filtered and added to
+
+  Background:
+    When I open materials designer page
+    Then I see material designer page
+    When I create materials with the following data
+      | name     | basis                          | lattice                                                 |
+      | Silicon  | Si 0 0 0                       | {"type":"FCC", "a":3.867, "b":3.867, "c":3.867}          |
+      | Graphene | C 0 0 0; C 0.33 0.33 0         | {"type":"HEX", "a":2.467, "b":2.467, "c":20}             |
+      | Copper   | Cu 0 0 0                       | {"type":"FCC", "a":2.560619,"b":2.560619,"c":2.560619}   |
+
+  Scenario: The count reflects the list, and the filter narrows it by name
+    Then I see the materials count showing "3"
+    And I see "3" materials in the list
+
+    When I filter the materials list by "graph"
+    Then I see "1" materials in the list
+    And I see the materials count showing "1 / 3"
+
+    When I clear the materials list filter
+    Then I see "3" materials in the list
+
+  Scenario: A filter matching nothing explains itself
+    When I filter the materials list by "zzz-no-such-material"
+    Then I see "0" materials in the list
+    And I see the empty state for the materials list
+
+  Scenario: Filtering does not disturb which material an action applies to
+    # Rows keep their real index while filtered, so renaming the only visible row must
+    # rename that material and not the one that happens to sit first in the list.
+    When I filter the materials list by "Copper"
+    And I set name of material with index "1" to "Renamed While Filtered"
+    And I clear the materials list filter
+    Then material with following name exists in state
+      | name                   | index   |
+      | Renamed While Filtered | $INT{3} |
+
+  Scenario: Removing a material can be undone, and it returns to its old position
+    When I delete materials with index "2"
+    Then I see "2" materials in the list
+    When I undo the removal
+    Then I see "3" materials in the list
+    And material with following name exists in state
+      | name     | index   |
+      | Graphene | $INT{2} |
+
+  Scenario: The add menu opens the Standata import dialog
+    When I select "Import from Standata" from the add material menu
+    Then I see Standata dialog

--- a/tests/cypress/support/step_definitions/I filter materials list.ts
+++ b/tests/cypress/support/step_definitions/I filter materials list.ts
@@ -1,0 +1,33 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+
+import MaterialDesignerPage from "../widgets/MaterialDesignerPage";
+
+const itemsList = () => new MaterialDesignerPage().designerWidget.itemsList;
+
+Given("I filter the materials list by {string}", (query: string) => {
+    itemsList().filterBy(query);
+});
+
+Given("I clear the materials list filter", () => {
+    itemsList().clearFilter();
+});
+
+Given("I see {string} materials in the list", (expected: string) => {
+    itemsList().assertRowCount(parseInt(expected, 10));
+});
+
+Given("I see the materials count showing {string}", (expected: string) => {
+    itemsList().getCountText().should("contain", expected);
+});
+
+Given("I see the empty state for the materials list", () => {
+    itemsList().browser.waitForVisible(itemsList().selectors.emptyState);
+});
+
+Given("I select {string} from the add material menu", (itemText: string) => {
+    itemsList().selectAddMenuItem(itemText);
+});
+
+Given("I undo the removal", () => {
+    itemsList().undoRemove();
+});

--- a/tests/cypress/support/widgets/ItemsListWidget.ts
+++ b/tests/cypress/support/widgets/ItemsListWidget.ts
@@ -9,10 +9,53 @@ export class ItemsListWidget extends Widget {
         nameInput: "input",
         itemByIndex: (index: number) => `ul>div:nth-of-type(${index}) li`,
         iconButtonDelete: ".icon-button-delete",
+        count: `${wrapper} .materials-count`,
+        filterInput: `${wrapper} .materials-filter input`,
+        rows: `${wrapper} ul>div`,
+        emptyState: `${wrapper} .materials-empty-state`,
+        addMenuButton: `${wrapper} .add-material-menu`,
+        // The add menu renders in a portal, so it is addressed outside the list wrapper.
+        addMenuItem: (text: string) => `li:contains("${text}")`,
+        undoRemove: ".undo-remove-material",
+        updatedDot: `${wrapper} .material-updated-dot`,
     };
 
     constructor() {
         super(wrapper);
+    }
+
+    getCountText() {
+        return this.browser.getElementText(this.selectors.count);
+    }
+
+    /**
+     * Asserts the number of visible rows. Uses a length assertion rather than reading `.length`,
+     * because `cy.get` fails outright on a selector that matches nothing - which is exactly the
+     * case a filter matching no materials needs to check.
+     */
+    assertRowCount(expected: number) {
+        return this.browser.get(this.selectors.rows).should("have.length", expected);
+    }
+
+    filterBy(query: string) {
+        this.browser.setInputValue(this.selectors.filterInput, query, true);
+    }
+
+    clearFilter() {
+        this.browser.clearInputValue(this.selectors.filterInput);
+    }
+
+    openAddMenu() {
+        this.browser.click(this.selectors.addMenuButton);
+    }
+
+    selectAddMenuItem(text: string) {
+        this.openAddMenu();
+        this.browser.get(this.selectors.addMenuItem(text)).click();
+    }
+
+    undoRemove() {
+        this.browser.click(this.selectors.undoRemove);
     }
 
     setItemName(itemIndex: number, name: string) {


### PR DESCRIPTION
Second in the chain — **stacked on #285**, so review that first and this diff reads clean.

## What

The materials list is the app's main navigation surface but was a bare column of names: no count, no search, no way to add a material from it, and a trash icon that removed one instantly with nothing to undo it.

- **Header** — count chip, name/formula filter, and an "add" menu (clone active · import from Standata · upload from disk).
- **Undoable removal** — restores the material at the position it came from.
- **Richer rows** — lattice type, site count, and a dot when the material differs from the version that entered the session.
- **Empty state** when the filter matches nothing.

## Notable decisions

**Reuses cove rather than rebuilding.** The add menu is cove's `Dropdown` (action-array API). The header menus keep MD's local `ButtonActivatedMenu` for now — Cypress addresses them as `.button-activated-menu[data-name="…"] li:nth-of-type(N)`, so swapping that implementation belongs in its own PR that updates the widgets alongside.

**The undo control is inside the snackbar message, not notistack's `action` slot.** cove's `AlertProvider` registers its own component for *every* notistack variant, and that component renders `message` only — an `action` passed the normal way silently never appears. Worth knowing before anyone else reaches for it. (I verified this the slow way.)

**Undo restores rather than rewinding.** The removed material object is captured before removal, so `originalSignature` (from #285) comes back with it and a never-edited material does not return looking edited. Restoring via the global undo stack would have been fewer lines but would revert whatever the user did after deleting.

**Filtering preserves real indices.** Rows carry their unfiltered index, so selection, rename and delete act on the right material while filtered.

**Two dialogs moved up.** `StandataImportDialog` and `UploadDialog` now live in `MaterialsDesigner`, since the header menu and the list's add menu both open them; the header calls `onOpenDialog`. Single instance, no duplicate mounts.

## Verified

Driven against the running app (Playwright):

- count chip `4`, filter `gra` → `1 / 4` and one row, `zzz` → empty state
- delete → 4→3 materials, Undo → back to 4 **at the original position** (`Silicon FCC, Graphene, MoS2 monolayer, Copper FCC`)
- add menu opens with all three entries
- `tsc --noEmit` and `eslint src` clean; no console errors

**Cypress compatibility checked deliberately:** the header renders *outside* the list's `ul`, so `ul > div:nth-of-type(N) li` still resolves to the Nth material (asserted: 4 rows for 4 materials), and the filter input is not inside an `li` so `… li input` still finds only name fields. Menu item ordering is unchanged.

## Deferred

Drag-and-drop file import (README TODO) is the natural next step — `UploadDialog` already contains the parsing, so it wants a shared drop-target extraction rather than a copy. Kept out to keep this diff reviewable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tg648kyhgbSwikBzhSjvXg)_