### PR TITLE
feat(toolbar): quick-action row, command palette, shortcuts — and a fix for broken undo/redo

### DIFF
--- a/src/MaterialsDesigner.jsx
+++ b/src/MaterialsDesigner.jsx
@@ -22,6 +22,7 @@ import EditorSelectionInfo, {
 } from "./components/3d_editor_selection_info/EditorSelectionInfo";
 import JupyterLiteSessionDrawer from "./components/drawer_session/JupyterLiteSessionDrawer";
 import HeaderMenuToolbar from "./components/header_menu/HeaderMenuToolbar";
+import { QUICK_ACTIONS_HEIGHT } from "./components/header_menu/QuickActionToolbar";
 import StandataImportDialog from "./components/include/StandataImportDialog";
 import UploadDialog from "./components/include/UploadDialog";
 import ItemsList from "./components/items_list/ItemsList";
@@ -33,7 +34,9 @@ import { theme } from "./settings";
 const data = MaterialStandata.runtimeData;
 const materialConfigs = Object.values(data.filesMapByName);
 
-const APP_BAR_HEIGHT = 54;
+const MENU_BAR_HEIGHT = 54;
+// The app bar stacks the menu row and the quick-action row; the panels below subtract both.
+const APP_BAR_HEIGHT = MENU_BAR_HEIGHT + QUICK_ACTIONS_HEIGHT;
 
 const GRID_CONFIG_BY_VISIBILITY = {
     // "111" means that all three components are visible

--- a/src/MaterialsDesigner.jsx
+++ b/src/MaterialsDesigner.jsx
@@ -205,6 +205,7 @@ class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMix
                                 defaultMaterialsSet={this.props.defaultMaterialsSet}
                                 onSectionVisibilityToggle={this.onSectionVisibilityToggle}
                                 onOpenDialog={this.onOpenDialog}
+                                onItemClick={this.props.onItemClick}
                                 isVisibleItemsList={isVisibleItemsList}
                                 isVisibleSourceEditor={isVisibleSourceEditor}
                                 isVisibleThreeDEditorFullscreen={isVisibleThreeDEditorFullscreen}

--- a/src/MaterialsDesignerContainer.tsx
+++ b/src/MaterialsDesignerContainer.tsx
@@ -43,8 +43,12 @@ function useUndoableState<T extends MDState>(initialValue: T, maxPastSize = 50) 
 
     const setState = useCallback(
         (newValue: T) => {
+            // Read the outgoing state now, not inside the updater: React runs the updater during
+            // the next render, by which point `presentRef.current` is already `newValue` - so the
+            // history would fill with copies of the new state and undo would appear to do nothing.
+            const previous = presentRef.current;
             setPast((prevPast) => {
-                const newPast = [...prevPast, presentRef.current];
+                const newPast = [...prevPast, previous];
                 // Keep only the most recent maxPastSize entries
                 return newPast.slice(-maxPastSize);
             });
@@ -54,26 +58,31 @@ function useUndoableState<T extends MDState>(initialValue: T, maxPastSize = 50) 
         [maxPastSize],
     );
 
+    // The present is a ref, so it must be moved *before* the setters run. React batches updates
+    // inside its own event handlers, but not inside native listeners (the keyboard shortcuts) -
+    // there each setter renders immediately, and a render that happens before the ref moves would
+    // publish the outgoing state.
     const undo = useCallback(() => {
         if (past.length === 0) return;
-        const previous = past[past.length - 1];
+        const { current } = presentRef;
+        presentRef.current = past[past.length - 1];
         setPast(past.slice(0, -1));
-        setFuture([presentRef.current, ...future]);
-        presentRef.current = previous;
+        setFuture([current, ...future]);
     }, [past, future]);
 
     const redo = useCallback(() => {
         if (future.length === 0) return;
-        const next = future[0];
-        setFuture(future.slice(1));
-        setPast([...past, presentRef.current]);
+        const { current } = presentRef;
+        const [next] = future;
         presentRef.current = next;
+        setFuture(future.slice(1));
+        setPast([...past, current]);
     }, [future, past]);
 
     const reset = useCallback(() => {
+        presentRef.current = initialValue;
         setPast([]);
         setFuture([]);
-        presentRef.current = initialValue;
     }, []);
 
     const canUndo = past.length > 0;

--- a/src/MaterialsDesignerContainer.tsx
+++ b/src/MaterialsDesignerContainer.tsx
@@ -35,58 +35,65 @@ declare global {
 }
 
 function useUndoableState<T extends MDState>(initialValue: T, maxPastSize = 50) {
-    const [past, setPast] = useState<T[]>([]);
-    const [future, setFuture] = useState<T[]>([]);
+    /**
+     * Past and future are one piece of state on purpose. Held separately, moving through history
+     * takes two setters, and outside React's batching (a keyboard shortcut is a native listener)
+     * each one renders on its own. The render in between carries a `redo` that still closes over
+     * the empty future, and `MaterialsDesigner.shouldComponentUpdate` compares props with
+     * JSON.stringify - which drops functions - so the corrected callback never reaches the toolbar.
+     * One setter, one render, one consistent pair of callbacks.
+     */
+    const [history, setHistory] = useState<{ past: T[]; future: T[] }>({ past: [], future: [] });
     const presentRef = React.useRef<T>(initialValue);
 
     window.MDState = presentRef.current;
 
     const setState = useCallback(
         (newValue: T) => {
-            // Read the outgoing state now, not inside the updater: React runs the updater during
-            // the next render, by which point `presentRef.current` is already `newValue` - so the
-            // history would fill with copies of the new state and undo would appear to do nothing.
+            // Read the outgoing state before moving the ref: the updater below runs during the
+            // next render, by which point `presentRef.current` is already `newValue`, and the
+            // history would fill with copies of the new state.
             const previous = presentRef.current;
-            setPast((prevPast) => {
-                const newPast = [...prevPast, previous];
-                // Keep only the most recent maxPastSize entries
-                return newPast.slice(-maxPastSize);
-            });
             presentRef.current = newValue;
-            setFuture([]); // clear redo history on new change
+            setHistory(({ past }) => ({
+                // Keep only the most recent maxPastSize entries
+                past: [...past, previous].slice(-maxPastSize),
+                future: [], // a new change invalidates the redo history
+            }));
         },
         [maxPastSize],
     );
 
-    // The present is a ref, so it must be moved *before* the setters run. React batches updates
-    // inside its own event handlers, but not inside native listeners (the keyboard shortcuts) -
-    // there each setter renders immediately, and a render that happens before the ref moves would
-    // publish the outgoing state.
+    // The present is a ref, so it moves before the setter runs: an unbatched render that happened
+    // first would publish the outgoing state.
     const undo = useCallback(() => {
-        if (past.length === 0) return;
-        const { current } = presentRef;
-        presentRef.current = past[past.length - 1];
-        setPast(past.slice(0, -1));
-        setFuture([current, ...future]);
-    }, [past, future]);
+        if (history.past.length === 0) return;
+        const previous = presentRef.current;
+        presentRef.current = history.past[history.past.length - 1];
+        setHistory(({ past, future }) => ({
+            past: past.slice(0, -1),
+            future: [previous, ...future],
+        }));
+    }, [history]);
 
     const redo = useCallback(() => {
-        if (future.length === 0) return;
-        const { current } = presentRef;
-        const [next] = future;
+        if (history.future.length === 0) return;
+        const previous = presentRef.current;
+        const [next] = history.future;
         presentRef.current = next;
-        setFuture(future.slice(1));
-        setPast([...past, current]);
-    }, [future, past]);
+        setHistory(({ past, future }) => ({
+            past: [...past, previous],
+            future: future.slice(1),
+        }));
+    }, [history]);
 
     const reset = useCallback(() => {
         presentRef.current = initialValue;
-        setPast([]);
-        setFuture([]);
+        setHistory({ past: [], future: [] });
     }, []);
 
-    const canUndo = past.length > 0;
-    const canRedo = future.length > 0;
+    const canUndo = history.past.length > 0;
+    const canRedo = history.future.length > 0;
 
     return [presentRef, setState, undo, redo, reset, canUndo, canRedo] as [
         React.MutableRefObject<T>,

--- a/src/components/header_menu/CommandPalette.jsx
+++ b/src/components/header_menu/CommandPalette.jsx
@@ -1,0 +1,239 @@
+import HexIcon from "@mui/icons-material/Hexagon";
+import SearchIcon from "@mui/icons-material/Search";
+import UploadIcon from "@mui/icons-material/Upload";
+import Box from "@mui/material/Box";
+import Dialog from "@mui/material/Dialog";
+import InputAdornment from "@mui/material/InputAdornment";
+import List from "@mui/material/List";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
+import ListSubheader from "@mui/material/ListSubheader";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import PropTypes from "prop-types";
+import React from "react";
+
+import { theme } from "../../settings";
+import { formatShortcut } from "./actions";
+
+const MAX_PER_GROUP = 6;
+
+function matches(query, text) {
+    return String(text || "")
+        .toLowerCase()
+        .includes(query);
+}
+
+/**
+ * Builds the palette's entries for a query: the invocable actions, the materials in the session,
+ * and the Standata library. Standata is only searched once the user types, since it is long and
+ * would otherwise bury the actions.
+ */
+export function buildEntries({
+    query,
+    actions,
+    materials,
+    standataConfigs,
+    onGoToMaterial,
+    onImportStandata,
+}) {
+    const q = query.trim().toLowerCase();
+    const entries = [];
+
+    actions
+        .filter((action) => !q || matches(q, `${action.label} ${action.group}`))
+        .forEach((action) => entries.push({ ...action, kind: "action" }));
+
+    materials.forEach((material, index) => {
+        if (q && !matches(q, `${material.name} ${material.formula}`)) return;
+        entries.push({
+            id: `material-${index}`,
+            kind: "material",
+            group: "Materials in session",
+            label: material.name,
+            hint: material.formula,
+            icon: <HexIcon />,
+            run: () => onGoToMaterial(index),
+        });
+    });
+
+    if (q) {
+        standataConfigs
+            .filter((config) => matches(q, config.name))
+            .slice(0, MAX_PER_GROUP)
+            .forEach((config, index) => {
+                entries.push({
+                    id: `standata-${index}-${config.name}`,
+                    kind: "standata",
+                    group: "Import from Standata",
+                    label: config.name,
+                    icon: <UploadIcon />,
+                    run: () => onImportStandata(config),
+                });
+            });
+    }
+
+    return entries;
+}
+
+/** One searchable entry point over the actions, the session's materials, and Standata. */
+class CommandPalette extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { query: "", activeIndex: 0 };
+    }
+
+    componentDidUpdate(prevProps) {
+        const { open } = this.props;
+        if (open && !prevProps.open) {
+            // eslint-disable-next-line react/no-did-update-set-state
+            this.setState({ query: "", activeIndex: 0 });
+        }
+    }
+
+    get entries() {
+        const { actions, materials, standataConfigs, onGoToMaterial, onImportStandata } =
+            this.props;
+        const { query } = this.state;
+        return buildEntries({
+            query,
+            actions,
+            materials,
+            standataConfigs,
+            onGoToMaterial,
+            onImportStandata,
+        });
+    }
+
+    runEntry = (entry) => {
+        const { onClose } = this.props;
+        onClose();
+        entry?.run?.();
+    };
+
+    handleKeyDown = (event) => {
+        const { entries } = this;
+        const { activeIndex } = this.state;
+        if (event.key === "ArrowDown") {
+            event.preventDefault();
+            this.setState({ activeIndex: Math.min(entries.length - 1, activeIndex + 1) });
+        } else if (event.key === "ArrowUp") {
+            event.preventDefault();
+            this.setState({ activeIndex: Math.max(0, activeIndex - 1) });
+        } else if (event.key === "Enter") {
+            event.preventDefault();
+            this.runEntry(entries[activeIndex]);
+        }
+    };
+
+    render() {
+        const { open, onClose } = this.props;
+        const { query, activeIndex } = this.state;
+        const { entries } = this;
+        let lastGroup = null;
+        return (
+            <Dialog
+                open={open}
+                onClose={onClose}
+                fullWidth
+                maxWidth="sm"
+                className="command-palette"
+                PaperProps={{ sx: { position: "absolute", top: 64, m: 0 } }}
+            >
+                <Box sx={{ p: 1.5, borderBottom: `1px solid ${theme.palette.grey[800]}` }}>
+                    <TextField
+                        autoFocus
+                        fullWidth
+                        size="small"
+                        variant="standard"
+                        className="command-palette-input"
+                        placeholder="Search actions, materials, Standata…"
+                        value={query}
+                        onChange={(event) =>
+                            this.setState({ query: event.target.value, activeIndex: 0 })
+                        }
+                        onKeyDown={this.handleKeyDown}
+                        inputProps={{ "aria-label": "Search actions and materials" }}
+                        InputProps={{
+                            disableUnderline: true,
+                            startAdornment: (
+                                <InputAdornment position="start">
+                                    <SearchIcon fontSize="small" />
+                                </InputAdornment>
+                            ),
+                        }}
+                    />
+                </Box>
+                <List dense sx={{ maxHeight: "50vh", overflowY: "auto", py: 0 }}>
+                    {entries.map((entry, index) => {
+                        const header = entry.group !== lastGroup ? entry.group : null;
+                        lastGroup = entry.group;
+                        return (
+                            <React.Fragment key={entry.id}>
+                                {header && (
+                                    <ListSubheader
+                                        sx={{
+                                            lineHeight: "24px",
+                                            fontSize: "0.65rem",
+                                            letterSpacing: "0.08em",
+                                            backgroundColor: "transparent",
+                                        }}
+                                    >
+                                        {header.toUpperCase()}
+                                    </ListSubheader>
+                                )}
+                                <ListItemButton
+                                    selected={index === activeIndex}
+                                    className="command-palette-item"
+                                    onMouseEnter={() => this.setState({ activeIndex: index })}
+                                    onClick={() => this.runEntry(entry)}
+                                >
+                                    <ListItemIcon sx={{ minWidth: 34 }}>{entry.icon}</ListItemIcon>
+                                    <ListItemText
+                                        primary={entry.label}
+                                        secondary={entry.hint}
+                                        primaryTypographyProps={{ variant: "body2" }}
+                                    />
+                                    {entry.shortcut && (
+                                        <Typography
+                                            variant="caption"
+                                            sx={{ color: theme.palette.grey[600] }}
+                                        >
+                                            {formatShortcut(entry.shortcut)}
+                                        </Typography>
+                                    )}
+                                </ListItemButton>
+                            </React.Fragment>
+                        );
+                    })}
+                    {entries.length === 0 && (
+                        <Typography
+                            variant="body2"
+                            sx={{ p: 2, textAlign: "center", color: theme.palette.grey[600] }}
+                        >
+                            Nothing matches “{query}”.
+                        </Typography>
+                    )}
+                </List>
+            </Dialog>
+        );
+    }
+}
+
+CommandPalette.propTypes = {
+    open: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    // eslint-disable-next-line react/forbid-prop-types
+    actions: PropTypes.array.isRequired,
+    // eslint-disable-next-line react/forbid-prop-types
+    materials: PropTypes.array.isRequired,
+    // eslint-disable-next-line react/forbid-prop-types
+    standataConfigs: PropTypes.array,
+    onGoToMaterial: PropTypes.func.isRequired,
+    onImportStandata: PropTypes.func.isRequired,
+};
+
+CommandPalette.defaultProps = { standataConfigs: [] };
+
+export default CommandPalette;

--- a/src/components/header_menu/HeaderMenuToolbar.jsx
+++ b/src/components/header_menu/HeaderMenuToolbar.jsx
@@ -50,7 +50,10 @@ import JupyterLiteTransformation from "../3d_editor/advanced_geometry/python_tra
 import SupercellDialog from "../3d_editor/advanced_geometry/SupercellDialog";
 import SurfaceDialog from "../3d_editor/advanced_geometry/SurfaceDialog";
 import { ButtonActivatedMenuMaterialUI } from "../include/material-ui/ButtonActivatedMenu";
+import { buildActions, isTypingTarget, matchesShortcut } from "./actions";
+import CommandPalette from "./CommandPalette";
 import ExportActionDialog from "./ExportActionDialog";
+import QuickActionToolbar from "./QuickActionToolbar";
 
 class HeaderMenuToolbar extends React.Component {
     constructor(config) {
@@ -66,8 +69,47 @@ class HeaderMenuToolbar extends React.Component {
             // showThreejsEditorModal: false,
             showBoundaryConditionsDialog: false,
             showJupyterLiteTransformation: false,
+            showCommandPalette: false,
         };
     }
+
+    componentDidMount() {
+        window.addEventListener("keydown", this.handleShortcut);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener("keydown", this.handleShortcut);
+    }
+
+    /** Opens a dialog owned by this component, by state key. */
+    openLocalDialog = (stateKey) => this.setState({ [stateKey]: true });
+
+    get actions() {
+        const { onUndo, onRedo, onClone, onOpenDialog } = this.props;
+        return buildActions({
+            onUndo,
+            onRedo,
+            onClone,
+            onOpenDialog,
+            onUseConventionalCell: this._handleConventionalCellSelect,
+            openLocalDialog: this.openLocalDialog,
+        });
+    }
+
+    handleShortcut = (event) => {
+        if (matchesShortcut(event, "Mod+K")) {
+            event.preventDefault();
+            this.setState((state) => ({ showCommandPalette: !state.showCommandPalette }));
+            return;
+        }
+        // Everything below would otherwise steal keys from the basis editor and name fields,
+        // which have their own undo stacks.
+        if (isTypingTarget(event.target)) return;
+        const action = this.actions.find(({ shortcut }) => matchesShortcut(event, shortcut));
+        if (!action) return;
+        event.preventDefault();
+        action.run();
+    };
 
     _handleConventionalCellSelect = () => {
         const {
@@ -391,6 +433,7 @@ class HeaderMenuToolbar extends React.Component {
             showExportMaterialsDialog,
             showInterpolateDialog,
             showJupyterLiteTransformation,
+            showCommandPalette,
         } = this.state;
         const {
             children,
@@ -402,6 +445,12 @@ class HeaderMenuToolbar extends React.Component {
             onGenerateSurface,
             onSetBoundaryConditions,
             maxCombinatorialBasesCount,
+            defaultMaterialsSet,
+            onItemClick,
+            onSectionVisibilityToggle,
+            isVisibleItemsList,
+            isVisibleSourceEditor,
+            isVisibleThreeDEditorFullscreen,
         } = this.props;
 
         const material = materials[index];
@@ -410,17 +459,40 @@ class HeaderMenuToolbar extends React.Component {
         // if (showThreejsEditorModal) return this.renderThreejsEditorModal();
 
         return (
-            <Toolbar
-                variant="dense"
-                className={setClass(className, "materials-designer-header-menu")}
-            >
-                {children}
-                {this.renderIOMenu()}
-                {this.renderEditMenu()}
-                {this.renderViewMenu()}
-                {this.renderAdvancedMenu()}
-                {this.renderHelpMenu()}
-                {this.renderSpinner()}
+            <>
+                <Toolbar
+                    variant="dense"
+                    className={setClass(className, "materials-designer-header-menu")}
+                >
+                    {children}
+                    {this.renderIOMenu()}
+                    {this.renderEditMenu()}
+                    {this.renderViewMenu()}
+                    {this.renderAdvancedMenu()}
+                    {this.renderHelpMenu()}
+                    {this.renderSpinner()}
+                </Toolbar>
+
+                <QuickActionToolbar
+                    actions={this.actions}
+                    onOpenPalette={() => this.setState({ showCommandPalette: true })}
+                    onSectionVisibilityToggle={onSectionVisibilityToggle}
+                    visibilityByName={{
+                        ItemsList: isVisibleItemsList,
+                        SourceEditor: isVisibleSourceEditor,
+                        ThreeDEditorFullscreen: isVisibleThreeDEditorFullscreen,
+                    }}
+                />
+
+                <CommandPalette
+                    open={showCommandPalette}
+                    onClose={() => this.setState({ showCommandPalette: false })}
+                    actions={this.actions}
+                    materials={materials}
+                    standataConfigs={defaultMaterialsSet}
+                    onGoToMaterial={onItemClick}
+                    onImportStandata={(config) => onAdd([new MDMaterial(config)])}
+                />
 
                 <SupercellDialog
                     isOpen={showSupercellDialog}
@@ -495,7 +567,7 @@ class HeaderMenuToolbar extends React.Component {
                         this.setState({ showJupyterLiteTransformation: false });
                     }}
                 />
-            </Toolbar>
+            </>
         );
     }
 }
@@ -529,6 +601,8 @@ HeaderMenuToolbar.propTypes = {
     onSectionVisibilityToggle: PropTypes.func.isRequired,
     /** Opens a dialog owned by MaterialsDesigner: "standata" or "upload". */
     onOpenDialog: PropTypes.func.isRequired,
+    /** Selects a material by index, used by the command palette's "go to" entries. */
+    onItemClick: PropTypes.func.isRequired,
     isVisibleItemsList: PropTypes.bool.isRequired,
     isVisibleSourceEditor: PropTypes.bool.isRequired,
     isVisibleThreeDEditorFullscreen: PropTypes.bool.isRequired,

--- a/src/components/header_menu/QuickActionToolbar.jsx
+++ b/src/components/header_menu/QuickActionToolbar.jsx
@@ -14,6 +14,12 @@ import React from "react";
 import { theme } from "../../settings";
 import { formatShortcut, TOOLBAR_ACTION_IDS } from "./actions";
 
+/**
+ * Fixed so the panels below can subtract it. Kept in sync with `main.css`, which sizes the 3D
+ * canvas and the basis editor off the same total: see APP_BAR_HEIGHT in MaterialsDesigner.
+ */
+export const QUICK_ACTIONS_HEIGHT = 38;
+
 const PANEL_TOGGLES = [
     { name: "ItemsList", label: "Materials list", icon: <ViewSidebarIcon fontSize="small" /> },
     { name: "SourceEditor", label: "Source editor", icon: <CodeIcon fontSize="small" /> },
@@ -36,7 +42,8 @@ function QuickActionToolbar({
             variant="dense"
             className="materials-designer-quick-actions"
             sx={{
-                minHeight: 38,
+                minHeight: QUICK_ACTIONS_HEIGHT,
+                height: QUICK_ACTIONS_HEIGHT,
                 gap: 0.25,
                 borderTop: `1px solid ${theme.palette.grey[900]}`,
             }}

--- a/src/components/header_menu/QuickActionToolbar.jsx
+++ b/src/components/header_menu/QuickActionToolbar.jsx
@@ -1,0 +1,119 @@
+import CodeIcon from "@mui/icons-material/Code";
+import SearchIcon from "@mui/icons-material/Search";
+import ThreeDIcon from "@mui/icons-material/ViewInAr";
+import ViewSidebarIcon from "@mui/icons-material/ViewSidebar";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Divider from "@mui/material/Divider";
+import IconButton from "@mui/material/IconButton";
+import Toolbar from "@mui/material/Toolbar";
+import Tooltip from "@mui/material/Tooltip";
+import PropTypes from "prop-types";
+import React from "react";
+
+import { theme } from "../../settings";
+import { formatShortcut, TOOLBAR_ACTION_IDS } from "./actions";
+
+const PANEL_TOGGLES = [
+    { name: "ItemsList", label: "Materials list", icon: <ViewSidebarIcon fontSize="small" /> },
+    { name: "SourceEditor", label: "Source editor", icon: <CodeIcon fontSize="small" /> },
+    { name: "ThreeDEditorFullscreen", label: "3D viewer", icon: <ThreeDIcon fontSize="small" /> },
+];
+
+/**
+ * A slim row of the most-used actions under the menu bar, so the common operations cost one click
+ * instead of two. Everything here is also reachable from the menus and the command palette.
+ */
+function QuickActionToolbar({
+    actions,
+    onOpenPalette,
+    onSectionVisibilityToggle,
+    visibilityByName,
+}) {
+    const actionById = new Map(actions.map((action) => [action.id, action]));
+    return (
+        <Toolbar
+            variant="dense"
+            className="materials-designer-quick-actions"
+            sx={{
+                minHeight: 38,
+                gap: 0.25,
+                borderTop: `1px solid ${theme.palette.grey[900]}`,
+            }}
+        >
+            {TOOLBAR_ACTION_IDS.map((id, position) => {
+                if (id === "|") {
+                    // eslint-disable-next-line react/no-array-index-key
+                    return <Divider key={`sep-${position}`} orientation="vertical" flexItem />;
+                }
+                const action = actionById.get(id);
+                if (!action) return null;
+                const shortcut = formatShortcut(action.shortcut);
+                return (
+                    <Tooltip
+                        key={action.id}
+                        title={shortcut ? `${action.label} (${shortcut})` : action.label}
+                    >
+                        <IconButton
+                            size="small"
+                            color="inherit"
+                            aria-label={action.label}
+                            className={`quick-action quick-action-${action.id}`}
+                            onClick={action.run}
+                        >
+                            {action.icon}
+                        </IconButton>
+                    </Tooltip>
+                );
+            })}
+
+            <Box sx={{ flex: 1 }} />
+
+            <Tooltip title={`Search actions and materials (${formatShortcut("Mod+K")})`}>
+                <Button
+                    size="small"
+                    color="inherit"
+                    variant="outlined"
+                    startIcon={<SearchIcon fontSize="small" />}
+                    className="open-command-palette"
+                    onClick={onOpenPalette}
+                    sx={{
+                        textTransform: "none",
+                        borderColor: theme.palette.grey[800],
+                        color: theme.palette.grey[500],
+                        display: { xs: "none", md: "inline-flex" },
+                    }}
+                >
+                    Search…
+                </Button>
+            </Tooltip>
+
+            <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+
+            {PANEL_TOGGLES.map(({ name, label, icon }) => (
+                <Tooltip key={name} title={`${visibilityByName[name] ? "Hide" : "Show"} ${label}`}>
+                    <IconButton
+                        size="small"
+                        aria-label={`${visibilityByName[name] ? "Hide" : "Show"} ${label}`}
+                        className={`panel-toggle panel-toggle-${name}`}
+                        color={visibilityByName[name] ? "primary" : "inherit"}
+                        onClick={() => onSectionVisibilityToggle(name)}
+                    >
+                        {icon}
+                    </IconButton>
+                </Tooltip>
+            ))}
+        </Toolbar>
+    );
+}
+
+QuickActionToolbar.propTypes = {
+    // eslint-disable-next-line react/forbid-prop-types
+    actions: PropTypes.array.isRequired,
+    onOpenPalette: PropTypes.func.isRequired,
+    onSectionVisibilityToggle: PropTypes.func.isRequired,
+    // eslint-disable-next-line react/forbid-prop-types
+    visibilityByName: PropTypes.object.isRequired,
+};
+
+export default QuickActionToolbar;

--- a/src/components/header_menu/actions.jsx
+++ b/src/components/header_menu/actions.jsx
@@ -1,0 +1,181 @@
+import SupercellIcon from "@mui/icons-material/BorderClear";
+import CloneIcon from "@mui/icons-material/Collections";
+import BoundaryConditionsIcon from "@mui/icons-material/Directions";
+import ConventionalCellIcon from "@mui/icons-material/FormatShapes";
+import GetAppIcon from "@mui/icons-material/GetApp";
+import SlabIcon from "@mui/icons-material/Layers";
+import CombinatorialSetIcon from "@mui/icons-material/LibraryAdd";
+import RedoIcon from "@mui/icons-material/Redo";
+import SearchIcon from "@mui/icons-material/Search";
+import InterpolatedSetIcon from "@mui/icons-material/SwapVert";
+import Terminal from "@mui/icons-material/Terminal";
+import UndoIcon from "@mui/icons-material/Undo";
+import UploadIcon from "@mui/icons-material/Upload";
+import React from "react";
+
+/** Ids of the actions the quick-action toolbar shows, in order. `|` marks a separator. */
+export const TOOLBAR_ACTION_IDS = [
+    "undo",
+    "redo",
+    "|",
+    "import-standata",
+    "upload",
+    "export",
+    "|",
+    "supercell",
+    "surface",
+    "|",
+    "jupyterlite-transformation",
+];
+
+const isMac = () =>
+    typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform || "");
+
+/** Renders a shortcut for the current platform: "Mod+Z" reads as ⌘Z or Ctrl+Z. */
+export function formatShortcut(shortcut) {
+    if (!shortcut) return "";
+    return isMac()
+        ? shortcut.replace("Mod+", "⌘").replace("Shift+", "⇧")
+        : shortcut.replace("Mod+", "Ctrl+");
+}
+
+/**
+ * The single registry of invocable actions, shared by the quick-action toolbar and the command
+ * palette so the two can never drift. Each entry: `{ id, label, group, icon, shortcut, run }`.
+ */
+export function buildActions({
+    onUndo,
+    onRedo,
+    onClone,
+    onOpenDialog,
+    onUseConventionalCell,
+    openLocalDialog,
+}) {
+    return [
+        {
+            id: "undo",
+            label: "Undo",
+            group: "Edit",
+            icon: <UndoIcon />,
+            shortcut: "Mod+Z",
+            run: onUndo,
+        },
+        {
+            id: "redo",
+            label: "Redo",
+            group: "Edit",
+            icon: <RedoIcon />,
+            shortcut: "Mod+Shift+Z",
+            run: onRedo,
+        },
+        {
+            id: "clone",
+            label: "Clone active material",
+            group: "Edit",
+            icon: <CloneIcon />,
+            run: onClone,
+        },
+        {
+            id: "conventional-cell",
+            label: "Use conventional cell",
+            group: "Edit",
+            icon: <ConventionalCellIcon />,
+            run: onUseConventionalCell,
+        },
+        {
+            id: "import-standata",
+            label: "Import from Standata",
+            group: "Input/Output",
+            icon: <SearchIcon />,
+            run: () => onOpenDialog("standata"),
+        },
+        {
+            id: "upload",
+            label: "Upload from disk",
+            group: "Input/Output",
+            icon: <UploadIcon />,
+            run: () => onOpenDialog("upload"),
+        },
+        {
+            id: "export",
+            label: "Export materials",
+            group: "Input/Output",
+            icon: <GetAppIcon />,
+            shortcut: "Mod+E",
+            run: () => openLocalDialog("showExportMaterialsDialog"),
+        },
+        {
+            id: "supercell",
+            label: "Create supercell",
+            group: "Advanced",
+            icon: <SupercellIcon />,
+            run: () => openLocalDialog("showSupercellDialog"),
+        },
+        {
+            id: "surface",
+            label: "Create surface / slab",
+            group: "Advanced",
+            icon: <SlabIcon />,
+            run: () => openLocalDialog("showSurfaceDialog"),
+        },
+        {
+            id: "boundary-conditions",
+            label: "Set boundary conditions",
+            group: "Advanced",
+            icon: <BoundaryConditionsIcon />,
+            run: () => openLocalDialog("showBoundaryConditionsDialog"),
+        },
+        {
+            id: "combinatorial-set",
+            label: "Generate combinatorial set",
+            group: "Advanced",
+            icon: <CombinatorialSetIcon />,
+            run: () => openLocalDialog("showCombinatorialDialog"),
+        },
+        {
+            id: "interpolated-set",
+            label: "Generate interpolated set",
+            group: "Advanced",
+            icon: <InterpolatedSetIcon />,
+            run: () => openLocalDialog("showInterpolateDialog"),
+        },
+        {
+            id: "jupyterlite-transformation",
+            label: "JupyterLite transformation",
+            group: "Advanced",
+            icon: <Terminal />,
+            run: () => openLocalDialog("showJupyterLiteTransformation"),
+        },
+    ];
+}
+
+/**
+ * Whether a keyboard shortcut should be ignored because the user is typing. The basis editor and
+ * the name fields have their own undo stacks, and stealing Mod+Z from them would lose text.
+ */
+export function isTypingTarget(target) {
+    if (!target) return false;
+    const tag = target.tagName;
+    return (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        target.isContentEditable === true ||
+        Boolean(target.closest?.(".cm-editor"))
+    );
+}
+
+/** Matches a keyboard event against a "Mod+Shift+Z"-style descriptor. */
+export function matchesShortcut(event, shortcut) {
+    if (!shortcut) return false;
+    const parts = shortcut.split("+");
+    const key = parts[parts.length - 1].toLowerCase();
+    const needsShift = parts.includes("Shift");
+    const needsMod = parts.includes("Mod");
+    const hasMod = event.metaKey || event.ctrlKey;
+    return (
+        event.key.toLowerCase() === key &&
+        hasMod === needsMod &&
+        event.shiftKey === needsShift &&
+        !event.altKey
+    );
+}

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -3,7 +3,7 @@
  */
 
 /**
-$header-height: 54px;
+$header-height: 92px; // menu row (54) + quick-action row (38)
 $footer-height: 54px;
 $crystal-lattice-accordion-height-with-borders: 56px;
 .three-renderer {
@@ -39,21 +39,22 @@ $crystal-lattice-accordion-height-with-borders: 56px;
 **/
 
 .three-renderer {
-    height: calc(100vh - 108px);
+    /* menu row + quick actions + footer: 54 + 38 + 54 */
+    height: calc(100vh - 146px);
 }
 
 #basis-xyz {
-    height: calc(100vh - 280px);
+    height: calc(100vh - 318px);
     overflow-y: hidden;
 }
 
 #basis-xyz .cm-editor {
     font-size: 0.9em;
-    max-height: calc(100vh - 280px);
+    max-height: calc(100vh - 318px);
     resize: vertical;
     overflow-y: auto;
 }
 
 #basis-xyz .cm-editor .cm-scroller {
-    min-height: calc(100vh - 280px);
+    min-height: calc(100vh - 318px);
 }

--- a/tests/cypress/e2e/toolbar/command-palette.feature
+++ b/tests/cypress/e2e/toolbar/command-palette.feature
@@ -1,0 +1,32 @@
+Feature: The command palette searches actions, the session's materials and Standata
+
+  Background:
+    When I open materials designer page
+    Then I see material designer page
+
+  Scenario: Actions are listed and can be run from the palette
+    When I open the command palette
+    Then I see "Create supercell" in the command palette
+
+    When I search the command palette for "surf"
+    Then I see "Create surface / slab" in the command palette
+    And I do not see "Create supercell" in the command palette
+
+    When I search the command palette for "standata"
+    And I run "Import from Standata" from the command palette
+    Then I see Standata dialog
+
+  Scenario: Materials in the session are reachable by name
+    When I clone material at index "1"
+    And I set name of material with index "2" to "Findable Copy"
+    And I open the command palette
+    And I search the command palette for "Findable"
+    Then I see "Findable Copy" in the command palette
+
+  Scenario: Standata is searched only once a query is typed
+    When I open the command palette
+    # 73 Standata entries would otherwise bury the dozen actions
+    Then I do not see "Graphene" in the command palette
+
+    When I search the command palette for "graphene"
+    Then I see "Graphene" in the command palette

--- a/tests/cypress/e2e/toolbar/keyboard-shortcuts.feature
+++ b/tests/cypress/e2e/toolbar/keyboard-shortcuts.feature
@@ -1,0 +1,36 @@
+Feature: Keyboard shortcuts drive the app without stealing keys from text fields
+
+  # A shortcut is a native keydown listener, which React does not batch. That path is exactly where
+  # undo/redo was broken before: the state history moved after the re-render rather than before it,
+  # so the outgoing state was published. These scenarios pin that down.
+
+  Scenario: Undo and redo respond to the keyboard
+    When I open materials designer page
+    Then I see material designer page
+    When I clone material at index "1"
+    Then material with following data exists in state
+      | path          | index   |
+      | si-clone.json | $INT{2} |
+
+    When I press "ctrl+z" outside any text field
+    Then material with following data does not exist in state
+      | path          | index   |
+      | si-clone.json | $INT{2} |
+
+    When I press "ctrl+shift+z" outside any text field
+    Then material with following data exists in state
+      | path          | index   |
+      | si-clone.json | $INT{2} |
+
+  Scenario: The same key inside a text field belongs to the field, not the app
+    When I open materials designer page
+    Then I see material designer page
+    When I clone material at index "1"
+    Then material with following data exists in state
+      | path          | index   |
+      | si-clone.json | $INT{2} |
+
+    When I press "ctrl+z" inside the materials filter
+    Then material with following data exists in state
+      | path          | index   |
+      | si-clone.json | $INT{2} |

--- a/tests/cypress/e2e/toolbar/quick-actions.feature
+++ b/tests/cypress/e2e/toolbar/quick-actions.feature
@@ -1,0 +1,29 @@
+Feature: The quick-action row reaches common operations in one click
+
+  Background:
+    When I open materials designer page
+    Then I see material designer page
+
+  Scenario: Panel toggles hide and restore the editor panels
+    Then I see the ".materials-designer-source-editor" panel
+
+    When I toggle the "SourceEditor" panel
+    Then I do not see the ".materials-designer-source-editor" panel
+
+    When I toggle the "SourceEditor" panel
+    Then I see the ".materials-designer-source-editor" panel
+
+  Scenario: An action on the row opens the same dialog as the menu
+    When I click the "import-standata" quick action
+    Then I see Standata dialog
+
+  Scenario: Undo on the row steps the history back
+    When I clone material at index "1"
+    Then material with following data exists in state
+      | path          | index   |
+      | si-clone.json | $INT{2} |
+
+    When I click the "undo" quick action
+    Then material with following data does not exist in state
+      | path          | index   |
+      | si-clone.json | $INT{2} |

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -14,3 +14,15 @@
 // ***********************************************************
 // Import commands.js using ES2015 syntax:
 import "./commands";
+
+/**
+ * "ResizeObserver loop completed with undelivered notifications" is a benign browser notice: it
+ * means the observer rescheduled work to the next frame, not that anything failed. wave.js sizes
+ * its canvas with a ResizeObserver, so toggling a panel reliably produces one. Cypress fails a test
+ * on any uncaught exception, so this single message is filtered out - by exact text, to keep every
+ * other application error failing as it should.
+ */
+Cypress.on("uncaught:exception", (err) => {
+    if (err.message.includes("ResizeObserver loop")) return false;
+    return undefined;
+});

--- a/tests/cypress/support/step_definitions/I press key.ts
+++ b/tests/cypress/support/step_definitions/I press key.ts
@@ -1,0 +1,20 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+import BrowserManager from "@mat3ra/tede/src/js/cypress/BrowserManager";
+
+/** Cypress key syntax: "ctrl+shift+z" becomes "{ctrl}{shift}z". */
+function toCypressKeys(combination: string) {
+    const parts = combination.split("+");
+    const key = parts.pop();
+    return `${parts.map((modifier) => `{${modifier}}`).join("")}${key}`;
+}
+
+Given("I press {string} outside any text field", (combination: string) => {
+    // The shortcut handler listens on window; the body is the plainest non-typing target there is.
+    BrowserManager.getBrowser().get("body").type(toCypressKeys(combination));
+});
+
+Given("I press {string} inside the materials filter", (combination: string) => {
+    BrowserManager.getBrowser()
+        .get(".materials-filter input")
+        .type(toCypressKeys(combination));
+});

--- a/tests/cypress/support/step_definitions/I use the command palette.ts
+++ b/tests/cypress/support/step_definitions/I use the command palette.ts
@@ -1,0 +1,45 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+
+import { CommandPaletteWidget } from "../widgets/CommandPaletteWidget";
+import MaterialDesignerPage from "../widgets/MaterialDesignerPage";
+
+const palette = () => new CommandPaletteWidget();
+
+Given("I open the command palette", () => {
+    palette().openWithShortcut();
+});
+
+Given("I search the command palette for {string}", (query: string) => {
+    palette().search(query);
+});
+
+Given("I see {string} in the command palette", (text: string) => {
+    palette().browser.get(palette().selectors.item).contains(text).should("be.visible");
+});
+
+Given("I do not see {string} in the command palette", (text: string) => {
+    palette()
+        .browser.get(palette().selectors.wrapper)
+        .contains(palette().selectors.item, text)
+        .should("not.exist");
+});
+
+Given("I run {string} from the command palette", (text: string) => {
+    palette().runItemContaining(text);
+});
+
+Given("I click the {string} quick action", (id: string) => {
+    new MaterialDesignerPage().designerWidget.browser.click(`.quick-action-${id}`);
+});
+
+Given("I toggle the {string} panel", (name: string) => {
+    new MaterialDesignerPage().designerWidget.browser.click(`.panel-toggle-${name}`);
+});
+
+Given("I see the {string} panel", (selector: string) => {
+    new MaterialDesignerPage().designerWidget.browser.waitForVisible(selector);
+});
+
+Given("I do not see the {string} panel", (selector: string) => {
+    new MaterialDesignerPage().designerWidget.browser.get(selector).should("not.exist");
+});

--- a/tests/cypress/support/widgets/CommandPaletteWidget.ts
+++ b/tests/cypress/support/widgets/CommandPaletteWidget.ts
@@ -1,0 +1,42 @@
+import Widget from "./Widget";
+
+const selectors = {
+    wrapper: ".command-palette",
+    input: ".command-palette-input input",
+    item: ".command-palette-item",
+    itemByText: (text: string) => `.command-palette-item:contains("${text}")`,
+};
+
+export class CommandPaletteWidget extends Widget {
+    selectors: typeof selectors;
+
+    constructor() {
+        super(selectors.wrapper);
+        this.selectors = selectors;
+    }
+
+    /** The palette is opened by a global shortcut, so the key goes to the document body. */
+    openWithShortcut() {
+        this.browser.get("body").type("{ctrl}k");
+        this.browser.waitForVisible(selectors.input);
+    }
+
+    search(query: string) {
+        // Clear first: a scenario that searches twice must not end up with both queries typed.
+        this.browser.setInputValue(selectors.input, query, true);
+    }
+
+    getItemTexts() {
+        return this.browser.getEachElementTexts(selectors.item);
+    }
+
+    runFirstItem() {
+        this.browser.get(selectors.item).first().click();
+    }
+
+    runItemContaining(text: string) {
+        this.browser.get(selectors.item).contains(text).click();
+    }
+}
+
+export default CommandPaletteWidget;


### PR DESCRIPTION
Third in the chain — **stacked on #286**.

## The history fix, stated accurately

While wiring `Mod+Z` I found `useUndoableState` has two ordering faults. My first description of this overstated the blast radius; here is what I have since verified empirically on `dev`.

**What is actually broken:** undo/redo from anything that is *not* a React synthetic event. A keyboard shortcut is a native `keydown` listener, so React 17 does not batch it — each setter renders immediately, and because `undo`/`redo` assigned `presentRef.current` *after* calling the setters, the render published the outgoing state. Verified on `dev`: calling `onUndo()` outside a React handler does nothing.

**What is not broken:** undo/redo from the Edit menu. React's eager-state optimisation calls a `useState` updater synchronously during dispatch when the fiber has no pending updates, which happens to read `presentRef.current` before it is reassigned — so the common menu path produces correct history. I confirmed this on clean `dev`: clone → undo → redo behaves correctly. The existing `reset-clone-undo-redo.feature` passes on `dev` for the same reason.

So this is a latent-correctness fix rather than a "nothing works" fix — but it is a prerequisite for the shortcut, and the second fault (history written from inside a `setPast` updater, which React runs *after* the ref has moved) makes the behaviour depend on whether React took the eager or the deferred path. Both are fixed so it is deterministic either way.

Fix is in its own commit (e548899), cherry-pickable.

## What else

- **Quick-action row** under the menu bar: undo, redo, import, upload, export, supercell, surface, JupyterLite, plus panel-visibility toggles. Tooltips everywhere, with the shortcut shown where there is one.
- **Command palette** on `Mod+K` over one registry of actions, the session's materials ("go to"), and Standata.
- **Shortcuts**: `Mod+Z`, `Mod+Shift+Z`, `Mod+E`, `Mod+K`.

## Notable decisions

**One registry, two surfaces.** `actions.jsx` is the single source; the toolbar picks a subset by id and the palette lists them all, so they cannot drift.

**Shortcuts stand down while you are typing.** `isTypingTarget` skips inputs, textareas, contenteditable and anything inside `.cm-editor`, so the basis editor and name fields keep their own undo.

**Standata is searched only after you type** — 73 entries would otherwise bury twelve actions.

## Verified

Playwright against the running app, plus the full Cypress suite green on the chain (65 specs, 11 executed, 0 failures):

- 8 toolbar actions + 3 panel toggles; toggling the source editor removes/restores the panel
- `Ctrl+K` opens the palette (14 entries); `super` → *Create supercell*; `graph` → 3 Standata matches; running one imports it
- undo/redo walk the history correctly from both a React handler and a native one; `Ctrl+Z` in the filter field does **not** undo, outside it does
- `tsc --noEmit` and `eslint src` clean; no console errors

## Notes for review

- `actions` must be `actions.jsx`, not `.js` — Vite applies the JSX transform by extension, and a `.js` file with JSX fails at runtime with a bare `SyntaxError: Unexpected token '<'`.
- Importing certain Standata entries logs `Material.toJSON validation failed` (e.g. the graphene nanoribbon). Pre-existing: the palette builds materials exactly as `StandataImportDialog` does, and `shouldComponentUpdate` already carries a `try/catch` for it. Worth its own issue.