### PR TITLE
feat(basis): table view alongside the XYZ text editor

### DIFF
--- a/src/components/source_editor/Basis.jsx
+++ b/src/components/source_editor/Basis.jsx
@@ -13,6 +13,7 @@ import React from "react";
 import s from "underscore.string";
 
 import { theme } from "../../settings";
+import BasisTable from "./BasisTable";
 import BasisText from "./BasisText";
 
 class BasisEditor extends React.Component {
@@ -23,6 +24,7 @@ class BasisEditor extends React.Component {
             xyzContent: props.material.getBasisAsXyz(),
             coordinateUnits: Made.ATOMIC_COORD_UNITS.crystal,
             checks: props.material.getConsistencyChecks(),
+            viewMode: "text",
         };
 
         this.handleBasisTextChange = this.handleBasisTextChange.bind(this);
@@ -75,8 +77,36 @@ class BasisEditor extends React.Component {
         );
     };
 
+    renderViewModeToggle() {
+        const { viewMode } = this.state;
+        return (
+            <ToggleButtonGroup
+                id="basis-view-mode"
+                value={viewMode}
+                exclusive
+                size="small"
+                onChange={(e, mode) => mode && this.setState({ viewMode: mode })}
+            >
+                <ToggleButton
+                    value="text"
+                    className="basis-view-text"
+                    sx={{ fontSize: theme.typography.caption.fontSize }}
+                >
+                    Text
+                </ToggleButton>
+                <ToggleButton
+                    value="table"
+                    className="basis-view-table"
+                    sx={{ fontSize: theme.typography.caption.fontSize }}
+                >
+                    Table
+                </ToggleButton>
+            </ToggleButtonGroup>
+        );
+    }
+
     render() {
-        const { coordinateUnits, checks, xyzContent } = this.state;
+        const { coordinateUnits, checks, xyzContent, viewMode } = this.state;
         const { material } = this.props;
         return (
             <Accordion defaultExpanded className="crystal-basis" elevation={2}>
@@ -85,13 +115,17 @@ class BasisEditor extends React.Component {
                 </AccordionSummary>
                 <AccordionDetails>
                     <Grid container spacing={0.125} id="crystal-basis">
-                        <Grid item xs={12}>
+                        <Grid
+                            item
+                            xs={12}
+                            sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}
+                        >
                             <ToggleButtonGroup
                                 id="basis-options"
                                 value={coordinateUnits}
-                                fullWidth
                                 exclusive
                                 size="small"
+                                sx={{ flex: 1 }}
                                 onChange={(e, unitsType) => {
                                     this.setState({
                                         coordinateUnits: unitsType,
@@ -102,13 +136,21 @@ class BasisEditor extends React.Component {
                                 {this.renderBasisUnitsLabel(Made.ATOMIC_COORD_UNITS.crystal)}
                                 {this.renderBasisUnitsLabel(Made.ATOMIC_COORD_UNITS.cartesian)}
                             </ToggleButtonGroup>
+                            {this.renderViewModeToggle()}
                         </Grid>
                         <Grid item xs={12}>
-                            <BasisText
-                                content={xyzContent}
-                                checks={checks}
-                                onChange={this.handleBasisTextChange}
-                            />
+                            {viewMode === "table" ? (
+                                <BasisTable
+                                    material={material}
+                                    onChange={this.handleBasisTextChange}
+                                />
+                            ) : (
+                                <BasisText
+                                    content={xyzContent}
+                                    checks={checks}
+                                    onChange={this.handleBasisTextChange}
+                                />
+                            )}
                         </Grid>
                     </Grid>
                 </AccordionDetails>

--- a/src/components/source_editor/BasisTable.jsx
+++ b/src/components/source_editor/BasisTable.jsx
@@ -1,0 +1,254 @@
+import AddIcon from "@mui/icons-material/Add";
+import DeleteIcon from "@mui/icons-material/Delete";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Checkbox from "@mui/material/Checkbox";
+import IconButton from "@mui/material/IconButton";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
+import PropTypes from "prop-types";
+import React from "react";
+
+import { theme } from "../../settings";
+
+const AXES = ["x", "y", "z"];
+const COORDINATE_PRECISION = 6;
+
+/** One row per site, read out of the material's basis. */
+export function rowsFromMaterial(material) {
+    const basis = material.getBasis();
+    const constraintsByIndex = new Map(
+        (basis.constraints || []).map(({ id, value }) => [id, value]),
+    );
+    return basis.elements.map(({ id, value }, index) => {
+        const coordinates = basis.coordinates[index]?.value ?? [0, 0, 0];
+        const constraint = constraintsByIndex.get(id) ?? [true, true, true];
+        return {
+            key: `${id}-${index}`,
+            element: value,
+            coordinates: coordinates.map((c) => Number(c)),
+            constraints: AXES.map((_, axis) => constraint[axis] !== false),
+        };
+    });
+}
+
+/**
+ * Serialises rows back to the XYZ text the basis editor already round-trips, so the table and the
+ * text view share one mutation path. Constraint columns are only written when a site is actually
+ * constrained, keeping the text identical to what the app produces today for free bases.
+ */
+export function rowsToXyz(rows) {
+    const anyConstrained = rows.some(({ constraints }) => constraints.some((free) => !free));
+    return `${rows
+        .map(({ element, coordinates, constraints }) => {
+            const position = coordinates
+                .map((value) => Number(value || 0).toFixed(COORDINATE_PRECISION))
+                .join("    ");
+            const flags = anyConstrained
+                ? `    ${constraints.map((free) => (free ? 1 : 0)).join(" ")}`
+                : "";
+            return `${element}    ${position}${flags}`;
+        })
+        .join("\n")}\n`;
+}
+
+/**
+ * Spreadsheet view of the basis: the same state as the XYZ text, but with one input per value so a
+ * single coordinate can be corrected without hand-editing a text buffer.
+ */
+class BasisTable extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { rows: rowsFromMaterial(props.material), editingKey: null };
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    UNSAFE_componentWillReceiveProps(nextProps) {
+        const { material } = this.props;
+        // Do not pull the material back in mid-keystroke: it would reformat the cell being typed.
+        if (material !== nextProps.material && this.state.editingKey === null) {
+            this.setState({ rows: rowsFromMaterial(nextProps.material) });
+        }
+    }
+
+    commit = (rows) => {
+        const { onChange } = this.props;
+        this.setState({ rows });
+        onChange(rowsToXyz(rows));
+    };
+
+    updateRow = (index, changes, { commit = true } = {}) => {
+        const { rows } = this.state;
+        const next = rows.map((row, i) => (i === index ? { ...row, ...changes } : row));
+        if (commit) this.commit(next);
+        else this.setState({ rows: next });
+    };
+
+    addRow = () => {
+        const { rows } = this.state;
+        this.commit([
+            ...rows,
+            {
+                key: `new-${rows.length}-${Date.now()}`,
+                element: rows[rows.length - 1]?.element || "Si",
+                coordinates: [0, 0, 0],
+                constraints: [true, true, true],
+            },
+        ]);
+    };
+
+    removeRow = (index) => {
+        const { rows } = this.state;
+        if (rows.length <= 1) return;
+        this.commit(rows.filter((_, i) => i !== index));
+    };
+
+    renderCoordinateCell(row, rowIndex, axis) {
+        const { editingKey } = this.state;
+        const isEditing = editingKey === `${row.key}-${axis}`;
+        const raw = row.coordinates[axis];
+        return (
+            <TableCell key={AXES[axis]} sx={{ p: 0.25 }}>
+                <TextField
+                    variant="standard"
+                    size="small"
+                    className={`basis-cell basis-cell-${AXES[axis]}`}
+                    value={isEditing ? raw : Number(raw).toFixed(3)}
+                    inputProps={{
+                        "aria-label": `${AXES[axis]} of site ${rowIndex + 1}`,
+                        style: { fontFamily: "monospace", fontSize: "0.78rem" },
+                    }}
+                    InputProps={{ disableUnderline: !isEditing }}
+                    onFocus={() => this.setState({ editingKey: `${row.key}-${axis}` })}
+                    onChange={(event) => {
+                        const coordinates = [...row.coordinates];
+                        coordinates[axis] = event.target.value;
+                        this.updateRow(rowIndex, { coordinates }, { commit: false });
+                    }}
+                    onBlur={() => {
+                        const coordinates = row.coordinates.map((value) => Number(value) || 0);
+                        this.setState({ editingKey: null });
+                        this.updateRow(rowIndex, { coordinates });
+                    }}
+                />
+            </TableCell>
+        );
+    }
+
+    render() {
+        const { rows } = this.state;
+        return (
+            <Box className="basis-table" sx={{ width: "100%", overflowX: "auto" }}>
+                <Table size="small" padding="none">
+                    <TableHead>
+                        <TableRow>
+                            <TableCell sx={{ color: theme.palette.grey[600] }}>#</TableCell>
+                            <TableCell sx={{ color: theme.palette.grey[600] }}>ELEMENT</TableCell>
+                            {AXES.map((axis) => (
+                                <TableCell key={axis} sx={{ color: theme.palette.grey[600] }}>
+                                    {axis.toUpperCase()}
+                                </TableCell>
+                            ))}
+                            <Tooltip title="Allow movement along x, y, z during relaxation">
+                                <TableCell sx={{ color: theme.palette.grey[600] }}>FREE</TableCell>
+                            </Tooltip>
+                            <TableCell />
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {rows.map((row, rowIndex) => (
+                            <TableRow key={row.key} hover className="basis-table-row">
+                                <TableCell sx={{ color: theme.palette.grey[600], width: 24 }}>
+                                    {rowIndex + 1}
+                                </TableCell>
+                                <TableCell sx={{ p: 0.25, width: 64 }}>
+                                    <TextField
+                                        variant="standard"
+                                        size="small"
+                                        className="basis-cell basis-cell-element"
+                                        value={row.element}
+                                        inputProps={{
+                                            "aria-label": `Element of site ${rowIndex + 1}`,
+                                            style: { fontSize: "0.78rem", fontWeight: 600 },
+                                        }}
+                                        InputProps={{ disableUnderline: true }}
+                                        onChange={(event) =>
+                                            this.updateRow(
+                                                rowIndex,
+                                                { element: event.target.value },
+                                                { commit: false },
+                                            )
+                                        }
+                                        onBlur={() => this.commit(this.state.rows)}
+                                    />
+                                </TableCell>
+                                {AXES.map((_, axis) =>
+                                    this.renderCoordinateCell(row, rowIndex, axis),
+                                )}
+                                <TableCell sx={{ whiteSpace: "nowrap" }}>
+                                    {row.constraints.map((isFree, axis) => (
+                                        <Checkbox
+                                            // eslint-disable-next-line react/no-array-index-key
+                                            key={AXES[axis]}
+                                            size="small"
+                                            checked={isFree}
+                                            className={`basis-constraint basis-constraint-${AXES[axis]}`}
+                                            inputProps={{
+                                                "aria-label": `${AXES[axis]} free for site ${
+                                                    rowIndex + 1
+                                                }`,
+                                            }}
+                                            sx={{ p: 0.25 }}
+                                            onChange={(event) => {
+                                                const constraints = [...row.constraints];
+                                                constraints[axis] = event.target.checked;
+                                                this.updateRow(rowIndex, { constraints });
+                                            }}
+                                        />
+                                    ))}
+                                </TableCell>
+                                <TableCell sx={{ width: 28 }}>
+                                    <Tooltip title="Remove site">
+                                        <span>
+                                            <IconButton
+                                                size="small"
+                                                className="basis-remove-site"
+                                                aria-label={`Remove site ${rowIndex + 1}`}
+                                                disabled={rows.length <= 1}
+                                                onClick={() => this.removeRow(rowIndex)}
+                                            >
+                                                <DeleteIcon sx={{ fontSize: "0.9rem" }} />
+                                            </IconButton>
+                                        </span>
+                                    </Tooltip>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+                <Button
+                    size="small"
+                    startIcon={<AddIcon />}
+                    className="basis-add-site"
+                    onClick={this.addRow}
+                    sx={{ mt: 0.5, textTransform: "none" }}
+                >
+                    Add site
+                </Button>
+            </Box>
+        );
+    }
+}
+
+BasisTable.propTypes = {
+    // eslint-disable-next-line react/forbid-prop-types
+    material: PropTypes.object.isRequired,
+    onChange: PropTypes.func.isRequired,
+};
+
+export default BasisTable;

--- a/tests/cypress/e2e/source-editor/basis-table.feature
+++ b/tests/cypress/e2e/source-editor/basis-table.feature
@@ -1,0 +1,45 @@
+Feature: The basis can be edited as a table as well as XYZ text
+
+  Background:
+    When I open materials designer page
+    Then I see material designer page
+    When I show the basis as a table
+    Then I see "2" sites in the basis table
+
+  Scenario: Editing one coordinate changes only that coordinate
+    When I set the "x" coordinate of site "2" to "0.4"
+    Then the basis text is
+      """
+      Si     0.000000    0.000000    0.000000
+      Si     0.400000    0.250000    0.250000
+      """
+
+  Scenario: Constraints are written only once a site is actually constrained
+    # An unconstrained basis must serialise exactly as it does today
+    Then the basis text is
+      """
+      Si     0.000000    0.000000    0.000000
+      Si     0.250000    0.250000    0.250000
+      """
+
+    When I untick the "z" constraint of site "1"
+    Then the basis text is
+      """
+      Si     0.000000    0.000000    0.000000 1 1 0
+      Si     0.250000    0.250000    0.250000 1 1 1
+      """
+
+  Scenario: Sites can be added and removed
+    When I add a site to the basis table
+    Then I see "3" sites in the basis table
+    When I remove site "3" from the basis table
+    Then I see "2" sites in the basis table
+
+  Scenario: The table and the text view show the same edits
+    When I set the "y" coordinate of site "1" to "0.1"
+    And I show the basis as text
+    Then the basis text is
+      """
+      Si     0.000000    0.100000    0.000000
+      Si     0.250000    0.250000    0.250000
+      """

--- a/tests/cypress/support/step_definitions/I edit the basis table.ts
+++ b/tests/cypress/support/step_definitions/I edit the basis table.ts
@@ -1,0 +1,61 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor";
+
+import { BasisTableWidget } from "../widgets/BasisTableWidget";
+import MaterialDesignerPage from "../widgets/MaterialDesignerPage";
+
+const table = () => new BasisTableWidget();
+
+Given("I show the basis as a table", () => {
+    table().showTable();
+});
+
+Given("I show the basis as text", () => {
+    table().showText();
+});
+
+Given("I see {string} sites in the basis table", (expected: string) => {
+    table().assertRowCount(parseInt(expected, 10));
+});
+
+Given(
+    "I set the {string} coordinate of site {string} to {string}",
+    (axis: string, site: string, value: string) => {
+        table().setCoordinate(parseInt(site, 10), axis, value);
+    },
+);
+
+Given("I set the element of site {string} to {string}", (site: string, value: string) => {
+    table().setElement(parseInt(site, 10), value);
+});
+
+Given("I untick the {string} constraint of site {string}", (axis: string, site: string) => {
+    table().toggleConstraint(parseInt(site, 10), axis);
+});
+
+Given("I add a site to the basis table", () => {
+    table().addSite();
+});
+
+Given("I remove site {string} from the basis table", (site: string) => {
+    table().removeSite(parseInt(site, 10));
+});
+
+/**
+ * Compares against the material's own XYZ rendering rather than the editor's DOM, so the check is
+ * about what was stored and holds whichever view is on screen.
+ */
+Given("the basis text is", (expected: string) => {
+    new MaterialDesignerPage().designerWidget.browser
+        .execute((win) => {
+            return win.MDState.materials[win.MDState.index].getBasisAsXyz();
+        })
+        .then((actual: string) => {
+            const normalise = (text: string) =>
+                text
+                    .trim()
+                    .split("\n")
+                    .map((line) => line.trim().replace(/\s+/g, " "))
+                    .join("\n");
+            expect(normalise(actual)).to.eq(normalise(expected));
+        });
+});

--- a/tests/cypress/support/widgets/BasisTableWidget.ts
+++ b/tests/cypress/support/widgets/BasisTableWidget.ts
@@ -1,0 +1,65 @@
+import Widget from "./Widget";
+
+const selectors = {
+    wrapper: ".basis-table",
+    textViewToggle: ".basis-view-text",
+    tableViewToggle: ".basis-view-table",
+    row: ".basis-table-row",
+    cell: (rowIndex: number, axis: string) =>
+        `.basis-table-row:nth-of-type(${rowIndex}) .basis-cell-${axis} input`,
+    elementCell: (rowIndex: number) =>
+        `.basis-table-row:nth-of-type(${rowIndex}) .basis-cell-element input`,
+    constraint: (rowIndex: number, axis: string) =>
+        `.basis-table-row:nth-of-type(${rowIndex}) .basis-constraint-${axis} input`,
+    addSite: ".basis-add-site",
+    removeSite: (rowIndex: number) =>
+        `.basis-table-row:nth-of-type(${rowIndex}) .basis-remove-site`,
+};
+
+export class BasisTableWidget extends Widget {
+    selectors: typeof selectors;
+
+    constructor() {
+        super(selectors.wrapper);
+        this.selectors = selectors;
+    }
+
+    showTable() {
+        this.browser.click(selectors.tableViewToggle);
+        this.browser.waitForVisible(selectors.wrapper);
+    }
+
+    showText() {
+        this.browser.click(selectors.textViewToggle);
+    }
+
+    assertRowCount(expected: number) {
+        return this.browser.get(selectors.row).should("have.length", expected);
+    }
+
+    setCoordinate(rowIndex: number, axis: string, value: string) {
+        this.browser.setInputValue(selectors.cell(rowIndex, axis), value, true);
+        // The edit is committed on blur, which is also what stops the cell being reformatted
+        // while it is being typed into.
+        this.browser.get(selectors.cell(rowIndex, axis)).blur();
+    }
+
+    setElement(rowIndex: number, value: string) {
+        this.browser.setInputValue(selectors.elementCell(rowIndex), value, true);
+        this.browser.get(selectors.elementCell(rowIndex)).blur();
+    }
+
+    toggleConstraint(rowIndex: number, axis: string) {
+        this.browser.click(selectors.constraint(rowIndex, axis));
+    }
+
+    addSite() {
+        this.browser.click(selectors.addSite);
+    }
+
+    removeSite(rowIndex: number) {
+        this.browser.click(selectors.removeSite(rowIndex));
+    }
+}
+
+export default BasisTableWidget;


### PR DESCRIPTION
Fourth in the chain — **stacked on #287**.

## What

Editing the basis meant hand-editing a raw XYZ buffer: fine for power users, awkward for correcting one coordinate or flipping one constraint. The Crystal Basis panel gets a **Text / Table** toggle.

The table gives one input per value, per-axis relaxation checkboxes, and add/remove site.

## Notable decisions

**Both views share one mutation path.** The table serialises back to the same XYZ text the editor already round-trips and calls the existing `handleBasisTextChange`, so there is one parser, one validation path, and no second way for the basis to be written. Constraint columns are emitted **only** when a site is actually constrained, so for an unconstrained basis the produced text is byte-identical to today's.

**A cell being typed into is not overwritten by incoming props.** Without that, a half-entered `0.` gets reformatted to `0.000` mid-keystroke and the value is unrecoverable.

**Plain MUI `Table`, not `DataGrid`.** `@mui/x-data-grid` is already a dependency (`UploadDialog` uses it), but its v6 editing model wants `processRowUpdate` plumbing and custom cell editors for the three constraint checkboxes. A plain table with inline inputs is fewer moving parts for the same result; worth revisiting if the basis ever needs sorting, virtualisation or column resizing — a 10k-site slab would want virtualisation regardless.

## Verified

Driven against the running app (Playwright), asserting the material's actual basis after each interaction:

| Action | Result |
| --- | --- |
| switch to Table | 2 rows, 6 constraint checkboxes |
| edit x of site 2 → `0.4` | `Si 0.400000 0.250000 0.250000` |
| untick z on site 1 | `Si 0.000000 0.000000 0.000000 1 1 0` |
| Add site / Remove site | 2 → 3 → 2 sites |
| switch back to Text | text view renders with the edits |

`tsc --noEmit` and `eslint src` clean; no console errors.

## Also here

Rebased onto #287's layout fix, so the status bar sits correctly under the two-row app bar.

## Next

The natural follow-up is D2b from the plan: highlight the selected 3D atoms as selected rows here, and vice versa. The status bar from #285 already consumes `onSelectionChanged`; the row-level wiring needs the controlled-selection prop that wave.js HEAD does not expose yet (`ThreeDEditor.jsx` carries its own "fully controlled or fully uncontrolled" TODO).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tg648kyhgbSwikBzhSjvXg)_