### PR TITLE
feature/SOF-8034 Chore: pin JupyterLite to the SOF-8034 deploy preview

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -1,9 +1,4 @@
 import { DarkMaterialUITheme } from "@mat3ra/cove/dist/theme";
 
 export const theme = DarkMaterialUITheme;
-// TEMPORARY [SOF-8034]: pinned to the jupyterlite#93 deploy preview, which builds its content from
-// the api-examples SOF-8034 branch and installs the `made` pre-release wheel from made#297. The
-// VITE_* path below only works where vite injects it -- consumers that bundle this package (web-app
-// via rspack) get undefined and silently fall back to the default JupyterLite.
-// Revert to the VITE_* lookup once made#297 and api-examples#361 merge.
 export const JUPYTERLITE_ORIGIN_URL = "https://deploy-preview-93--mat3ra-jupyterlite.netlify.app";

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,6 +1,9 @@
 import { DarkMaterialUITheme } from "@mat3ra/cove/dist/theme";
 
 export const theme = DarkMaterialUITheme;
-const JUPYTERLITE_DEVELOPMENT_URL = process.env.VITE_JUPYTERLITE_DEVELOPMENT_URL;
-export const JUPYTERLITE_ORIGIN_URL =
-    process.env.VITE_USE_JUPYTERLITE_DEV_URL === "true" ? JUPYTERLITE_DEVELOPMENT_URL : undefined; // if not set, will use the default URL
+// TEMPORARY [SOF-8034]: pinned to the jupyterlite#93 deploy preview, which builds its content from
+// the api-examples SOF-8034 branch and installs the `made` pre-release wheel from made#297. The
+// VITE_* path below only works where vite injects it -- consumers that bundle this package (web-app
+// via rspack) get undefined and silently fall back to the default JupyterLite.
+// Revert to the VITE_* lookup once made#297 and api-examples#361 merge.
+export const JUPYTERLITE_ORIGIN_URL = "https://deploy-preview-93--mat3ra-jupyterlite.netlify.app";


### PR DESCRIPTION
Part of SOF-8034, alongside [made#297](https://github.com/mat3ra/made/pull/297), [api-examples#361](https://github.com/mat3ra/api-examples/pull/361), [jupyterlite#93](https://github.com/mat3ra/jupyterlite/pull/93) and [web-app#2964](https://github.com/mat3ra/web-app/pull/2964).

## The bug this exposes

`src/settings.js` resolved the JupyterLite origin from `process.env.VITE_USE_JUPYTERLITE_DEV_URL`. That works when **vite** builds this repo, but any consumer that bundles the package with a different bundler gets `undefined` and falls through to the default JupyterLite — silently. In web-app (rspack, no matching `DefinePlugin`) the Transformation dialog therefore ran **stale notebooks against the released `made`**, while web-app's own session drawer, which reads `settings.json`, used the intended one. Two JupyterLites in one app, disagreeing, with no error.

Hardcoding the origin makes every consumer agree while SOF-8034 is in flight.

## TEMPORARY — do not merge as-is

Restore the `VITE_*` lookup once made#297 and api-examples#361 merge. The lasting fix is worth a follow-up: either accept `originURL` as a prop so the host app decides, or read it from runtime config rather than a build-time `process.env` only one bundler fills in.

## Verified

web-app rebuilt with the matching `DefinePlugin` serves the preview URL in its client bundle, and the Transformation dialog loads the SOF-8034 JupyterLite — which installs the `made` pre-release wheel from made#297 and the api-examples SOF-8034 notebooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)