### PR TITLE
fix(history): a truthful undo stack, and controls that admit when they cannot act

### DIFF
--- a/src/MaterialsDesigner.jsx
+++ b/src/MaterialsDesigner.jsx
@@ -7,7 +7,6 @@ import { Allotment } from "allotment";
 import "allotment/dist/style.css";
 import AppBar from "@mui/material/AppBar";
 import Box from "@mui/material/Box";
-import Grid from "@mui/material/Grid";
 import IconButton from "@mui/material/IconButton";
 import Paper from "@mui/material/Paper";
 import ScopedCssBaseline from "@mui/material/ScopedCssBaseline";
@@ -44,6 +43,21 @@ const APP_BAR_HEIGHT = MENU_BAR_HEIGHT + QUICK_ACTIONS_HEIGHT;
 const DEFAULT_PANE_SIZES = [280, 440, 780];
 const PANE_SIZES_STORAGE_KEY = "materials-designer.paneSizes";
 
+/** Widths the user last dragged to, falling back to the defaults. */
+function readStoredPaneSizes() {
+    try {
+        const stored = JSON.parse(window.localStorage.getItem(PANE_SIZES_STORAGE_KEY));
+        const isUsable =
+            Array.isArray(stored) &&
+            stored.length === DEFAULT_PANE_SIZES.length &&
+            stored.every((size) => Number.isFinite(size) && size > 0);
+        return isUsable ? stored : DEFAULT_PANE_SIZES;
+    } catch (error) {
+        // Storage can be unavailable (private browsing, embedded hosts): use the defaults.
+        return DEFAULT_PANE_SIZES;
+    }
+}
+
 class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMixin) {
     constructor(props) {
         super(props);
@@ -57,6 +71,9 @@ class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMix
             openDialog: null,
         };
         this.containerRef = React.createRef();
+        // Read once: `defaultSizes` is consumed on mount, and `preferredSize` is read again only
+        // when a hidden pane comes back. Re-reading storage on every render buys nothing.
+        this.paneSizes = readStoredPaneSizes();
     }
 
     shouldComponentUpdate(nextProps, nextState) {
@@ -75,25 +92,13 @@ class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMix
         }
     }
 
-    /** Widths the user last dragged to, falling back to the defaults. */
-    // eslint-disable-next-line class-methods-use-this
-    get storedPaneSizes() {
-        try {
-            const stored = JSON.parse(window.localStorage.getItem(PANE_SIZES_STORAGE_KEY));
-            const isUsable =
-                Array.isArray(stored) &&
-                stored.length === DEFAULT_PANE_SIZES.length &&
-                stored.every((size) => Number.isFinite(size) && size > 0);
-            return isUsable ? stored : DEFAULT_PANE_SIZES;
-        } catch (error) {
-            // Storage can be unavailable (private browsing, embedded hosts): use the defaults.
-            return DEFAULT_PANE_SIZES;
-        }
-    }
-
     onPanesResized = (sizes) => {
+        // Allotment reports a hidden pane as 0 wide. Persisting that zero would fail the
+        // "every size > 0" check on the next load and silently drop the whole layout, so a pane
+        // that is not on screen keeps whatever width it last had.
+        this.paneSizes = sizes.map((size, i) => (size > 0 ? size : this.paneSizes[i]));
         try {
-            window.localStorage.setItem(PANE_SIZES_STORAGE_KEY, JSON.stringify(sizes));
+            window.localStorage.setItem(PANE_SIZES_STORAGE_KEY, JSON.stringify(this.paneSizes));
         } catch (error) {
             // Not being able to remember the layout is not worth interrupting the session for.
         }
@@ -151,6 +156,8 @@ class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMix
                                 mdState={mdState}
                                 onUndo={this.props.onUndo}
                                 onRedo={this.props.onRedo}
+                                canUndo={this.props.canUndo}
+                                canRedo={this.props.canRedo}
                                 onReset={this.props.onReset}
                                 onClone={this.props.onClone}
                                 onToggleIsNonPeriodic={this.props.onToggleIsNonPeriodic}
@@ -210,13 +217,13 @@ class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMix
                                 id="materials-designer-container"
                                 className="materials-designer-panes"
                                 ref={this.containerRef}
-                                defaultSizes={this.storedPaneSizes}
+                                defaultSizes={this.paneSizes}
                                 onDragEnd={this.onPanesResized}
                             >
                                 <Allotment.Pane
                                     visible={isVisibleItemsList}
                                     minSize={220}
-                                    preferredSize={this.storedPaneSizes[0]}
+                                    preferredSize={this.paneSizes[0]}
                                 >
                                     <Box
                                         className="materials-designer-items-list"
@@ -240,7 +247,7 @@ class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMix
                                 <Allotment.Pane
                                     visible={isVisibleSourceEditor}
                                     minSize={300}
-                                    preferredSize={this.storedPaneSizes[1]}
+                                    preferredSize={this.paneSizes[1]}
                                 >
                                     <Box
                                         className="materials-designer-source-editor"
@@ -355,6 +362,8 @@ MaterialsDesigner.propTypes = {
     onUndo: PropTypes.func,
     onRedo: PropTypes.func,
     onReset: PropTypes.func,
+    canUndo: PropTypes.bool,
+    canRedo: PropTypes.bool,
 
     onAdd: PropTypes.func,
     onExport: PropTypes.func,
@@ -376,6 +385,8 @@ MaterialsDesigner.propTypes = {
 
 MaterialsDesigner.defaultProps = {
     defaultMaterialsSet: materialConfigs,
+    canUndo: true,
+    canRedo: true,
 };
 
 export default MaterialsDesigner;

--- a/src/MaterialsDesignerContainer.tsx
+++ b/src/MaterialsDesignerContainer.tsx
@@ -49,12 +49,17 @@ function useUndoableState<T extends MDState>(initialValue: T, maxPastSize = 50) 
     window.MDState = presentRef.current;
 
     const setState = useCallback(
-        (newValue: T) => {
+        (newValue: T, { recordHistory = true }: { recordHistory?: boolean } = {}) => {
             // Read the outgoing state before moving the ref: the updater below runs during the
             // next render, by which point `presentRef.current` is already `newValue`, and the
             // history would fill with copies of the new state.
             const previous = presentRef.current;
             presentRef.current = newValue;
+            if (!recordHistory) {
+                // Still a state change, so still a render - just not one the user can undo.
+                setHistory((history_) => ({ ...history_ }));
+                return;
+            }
             setHistory(({ past }) => ({
                 // Keep only the most recent maxPastSize entries
                 past: [...past, previous].slice(-maxPastSize),
@@ -135,15 +140,18 @@ export function MaterialsDesignerContainer({
     // would also mean re-hashing every material on every render.
     const baselineMaterials = React.useMemo(() => initialMaterials.map(stampOriginalSignature), []);
 
-    const [mdState, setMdState, undo, redo, reset] = useUndoableState<MDState>({
+    const [mdState, setMdState, undo, redo, reset, canUndo, canRedo] = useUndoableState<MDState>({
         index: 0,
         isLoading: false,
         materials: baselineMaterials,
         updatedIndices: [],
     });
 
+    // Mirroring the loading flag is not an edit. Recorded as one, it would run on mount and leave
+    // a phantom entry in the history: undo would light up before the user had done anything, and
+    // the first Mod+Z would swap the state for an identical copy of itself.
     useEffect(() => {
-        setMdState({ ...mdState.current, isLoading });
+        setMdState({ ...mdState.current, isLoading }, { recordHistory: false });
     }, [isLoading]);
 
     const onUpdate = useCallback((material: MDMaterial, index: number) => {
@@ -154,8 +162,10 @@ export function MaterialsDesignerContainer({
         setMdState(materialsUpdateNameForOne(mdState.current, { name, index }));
     }, []);
 
+    // Which material you are looking at is navigation, not an edit. Recorded, clicking through
+    // five materials would cost five presses of Mod+Z to get back to the last thing you changed.
     const onItemClick = useCallback((index: number) => {
-        setMdState(materialsUpdateIndex(mdState.current, { index }));
+        setMdState(materialsUpdateIndex(mdState.current, { index }), { recordHistory: false });
     }, []);
 
     const onClone = useCallback(() => {
@@ -193,8 +203,12 @@ export function MaterialsDesignerContainer({
         setMdState(materialsInsertAt(mdState.current, { material, index }));
     }, []);
 
+    // Exporting writes a file and returns the state untouched; recorded, it would leave a
+    // duplicate snapshot on the stack and an Undo that visibly does nothing.
     const onExport = useCallback((format: "json" | "poscar", useMultiple: boolean) => {
-        setMdState(materialsExport(mdState.current, { format, useMultiple }));
+        setMdState(materialsExport(mdState.current, { format, useMultiple }), {
+            recordHistory: false,
+        });
     }, []);
 
     const content = (
@@ -216,6 +230,8 @@ export function MaterialsDesignerContainer({
             onRemove={onRemove}
             onRestore={onRestore}
             onExport={onExport}
+            canUndo={canUndo}
+            canRedo={canRedo}
             {...props}
         />
     );

--- a/src/components/3d_editor_selection_info/EditorSelectionInfo.jsx
+++ b/src/components/3d_editor_selection_info/EditorSelectionInfo.jsx
@@ -1,26 +1,33 @@
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
-import Stack from "@mui/material/Stack";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { formatShortcut } from "../header_menu/actions";
 import { theme } from "../../settings";
-import { describeMaterial, SELECTION_HINTS } from "./materialInfo";
+import { describeMaterial } from "./materialInfo";
 
-export const FOOTER_HEIGHT = 54;
+/**
+ * A single strip, not a panel: label and value sit on one line so the bar can stay out of the
+ * way. Every pixel here is a pixel the 3D canvas does not get.
+ */
+export const FOOTER_HEIGHT = 36;
 
 function InfoGroup({ label, children, title, className }) {
     const content = (
-        <Stack spacing={0.25} sx={{ minWidth: 0 }} className={className}>
+        <Box
+            className={className}
+            sx={{ display: "flex", alignItems: "baseline", gap: 0.75, minWidth: 0 }}
+        >
             <Typography
                 variant="caption"
                 sx={{
                     fontSize: "0.6rem",
                     letterSpacing: "0.08em",
-                    lineHeight: 1,
                     color: theme.palette.grey[600],
+                    flexShrink: 0,
                 }}
             >
                 {label}
@@ -30,7 +37,6 @@ function InfoGroup({ label, children, title, className }) {
                 sx={{
                     fontFamily: "monospace",
                     fontSize: "0.78rem",
-                    lineHeight: 1.2,
                     whiteSpace: "nowrap",
                     overflow: "hidden",
                     textOverflow: "ellipsis",
@@ -38,7 +44,7 @@ function InfoGroup({ label, children, title, className }) {
             >
                 {children}
             </Typography>
-        </Stack>
+        </Box>
     );
     return title ? <Tooltip title={title}>{content}</Tooltip> : content;
 }
@@ -53,10 +59,9 @@ InfoGroup.propTypes = {
 InfoGroup.defaultProps = { children: null, title: undefined, className: undefined };
 
 /**
- * Status bar under the three editor panels: what is selected in the 3D editor, what the active
- * material is, and where it sits in the list.
- */
-/**
+ * Status bar under the three editor panels: what the active material is and where it sits in the
+ * list.
+ *
  * Selection detail is deliberately absent: wave.js renders its own StatusBar and
  * SelectionInspector inside the 3D editor, so what is selected is described there, next to the
  * atoms it refers to. This bar covers what wave cannot know - the material and the list around it.
@@ -76,8 +81,10 @@ const EditorSelectionInfo = function EditorSelectionInfo({ material, index, mate
                 overflowX: "auto",
             }}
         >
-            <InfoGroup label="MATERIAL" className="status-material">{materialInfo.text}</InfoGroup>
-            <Divider orientation="vertical" flexItem />
+            <InfoGroup label="MATERIAL" className="status-material">
+                {materialInfo.text}
+            </InfoGroup>
+            <Divider orientation="vertical" flexItem sx={{ my: 0.75 }} />
             <InfoGroup label="POSITION" className="status-position">
                 {materialsCount ? `${index + 1} / ${materialsCount}` : "—"}
             </InfoGroup>
@@ -90,7 +97,7 @@ const EditorSelectionInfo = function EditorSelectionInfo({ material, index, mate
                     display: { xs: "none", lg: "block" },
                 }}
             >
-                {SELECTION_HINTS}
+                {`Shift+U / Shift+D switch material · ${formatShortcut("Mod+K")} to search`}
             </Typography>
         </Box>
     );

--- a/src/components/3d_editor_selection_info/materialInfo.js
+++ b/src/components/3d_editor_selection_info/materialInfo.js
@@ -1,5 +1,3 @@
-export const SELECTION_HINTS = "Shift+U / Shift+D switch material";
-
 /** Formula, atom count and lattice of the active material, for the status bar. */
 export function describeMaterial(material) {
     if (!material) return { text: "—" };

--- a/src/components/header_menu/CommandPalette.jsx
+++ b/src/components/header_menu/CommandPalette.jsx
@@ -42,6 +42,9 @@ export function buildEntries({
     const entries = [];
 
     actions
+        // An unavailable action is left out rather than greyed out: a palette is a place to reach
+        // for something, and offering "Undo" with an empty history is only a dead end.
+        .filter((action) => !action.disabled)
         .filter((action) => !q || matches(q, `${action.label} ${action.group}`))
         .forEach((action) => entries.push({ ...action, kind: "action" }));
 

--- a/src/components/header_menu/HeaderMenuToolbar.jsx
+++ b/src/components/header_menu/HeaderMenuToolbar.jsx
@@ -85,7 +85,7 @@ class HeaderMenuToolbar extends React.Component {
     openLocalDialog = (stateKey) => this.setState({ [stateKey]: true });
 
     get actions() {
-        const { onUndo, onRedo, onClone, onOpenDialog } = this.props;
+        const { onUndo, onRedo, onClone, onOpenDialog, canUndo, canRedo } = this.props;
         return buildActions({
             onUndo,
             onRedo,
@@ -93,6 +93,8 @@ class HeaderMenuToolbar extends React.Component {
             onOpenDialog,
             onUseConventionalCell: this._handleConventionalCellSelect,
             openLocalDialog: this.openLocalDialog,
+            canUndo,
+            canRedo,
         });
     }
 
@@ -107,7 +109,10 @@ class HeaderMenuToolbar extends React.Component {
         if (isTypingTarget(event.target)) return;
         const action = this.actions.find(({ shortcut }) => matchesShortcut(event, shortcut));
         if (!action) return;
+        // Swallow the key even when the action is unavailable: Mod+Z with an empty history should
+        // do nothing here, not fall through to the browser's own undo.
         event.preventDefault();
+        if (action.disabled) return;
         action.run();
     };
 
@@ -165,16 +170,17 @@ class HeaderMenuToolbar extends React.Component {
     }
 
     renderEditMenu() {
-        const { onUndo, onRedo, onReset, onClone, onToggleIsNonPeriodic } = this.props;
+        const { onUndo, onRedo, onReset, onClone, onToggleIsNonPeriodic, canUndo, canRedo } =
+            this.props;
         return (
             <ButtonActivatedMenuMaterialUI title="Edit">
-                <MenuItem onClick={onUndo}>
+                <MenuItem disabled={!canUndo} onClick={onUndo}>
                     <ListItemIcon>
                         <UndoIcon />
                     </ListItemIcon>
                     Undo
                 </MenuItem>
-                <MenuItem onClick={onRedo}>
+                <MenuItem disabled={!canRedo} onClick={onRedo}>
                     <ListItemIcon>
                         <RedoIcon />
                     </ListItemIcon>
@@ -589,6 +595,8 @@ HeaderMenuToolbar.propTypes = {
     onUpdate: PropTypes.func.isRequired,
     onUndo: PropTypes.func.isRequired,
     onRedo: PropTypes.func.isRequired,
+    canUndo: PropTypes.bool,
+    canRedo: PropTypes.bool,
     onReset: PropTypes.func.isRequired,
     onClone: PropTypes.func.isRequired,
     onToggleIsNonPeriodic: PropTypes.func.isRequired,
@@ -622,6 +630,9 @@ HeaderMenuToolbar.defaultProps = {
     onExit: undefined,
     openImportModal: undefined,
     closeImportModal: undefined,
+    // Undefined reads as "available": embedders that do not track history keep working controls.
+    canUndo: true,
+    canRedo: true,
 };
 
 export default HeaderMenuToolbar;

--- a/src/components/header_menu/QuickActionToolbar.jsx
+++ b/src/components/header_menu/QuickActionToolbar.jsx
@@ -37,6 +37,9 @@ function QuickActionToolbar({
     visibilityByName,
 }) {
     const actionById = new Map(actions.map((action) => [action.id, action]));
+    // The app always keeps one panel on screen. Rather than let the last toggle look live and do
+    // nothing, grey it out and say why.
+    const visibleCount = PANEL_TOGGLES.filter(({ name }) => visibilityByName[name]).length;
     return (
         <Toolbar
             variant="dense"
@@ -61,15 +64,19 @@ function QuickActionToolbar({
                         key={action.id}
                         title={shortcut ? `${action.label} (${shortcut})` : action.label}
                     >
-                        <IconButton
-                            size="small"
-                            color="inherit"
-                            aria-label={action.label}
-                            className={`quick-action quick-action-${action.id}`}
-                            onClick={action.run}
-                        >
-                            {action.icon}
-                        </IconButton>
+                        {/* A disabled button fires no events, so the tooltip needs a live wrapper */}
+                        <Box component="span" sx={{ display: "inline-flex" }}>
+                            <IconButton
+                                size="small"
+                                color="inherit"
+                                disabled={Boolean(action.disabled)}
+                                aria-label={action.label}
+                                className={`quick-action quick-action-${action.id}`}
+                                onClick={action.run}
+                            >
+                                {action.icon}
+                            </IconButton>
+                        </Box>
                     </Tooltip>
                 );
             })}
@@ -97,19 +104,32 @@ function QuickActionToolbar({
 
             <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
 
-            {PANEL_TOGGLES.map(({ name, label, icon }) => (
-                <Tooltip key={name} title={`${visibilityByName[name] ? "Hide" : "Show"} ${label}`}>
-                    <IconButton
-                        size="small"
-                        aria-label={`${visibilityByName[name] ? "Hide" : "Show"} ${label}`}
-                        className={`panel-toggle panel-toggle-${name}`}
-                        color={visibilityByName[name] ? "primary" : "inherit"}
-                        onClick={() => onSectionVisibilityToggle(name)}
+            {PANEL_TOGGLES.map(({ name, label, icon }) => {
+                const isVisible = visibilityByName[name];
+                const isLastVisible = isVisible && visibleCount === 1;
+                const verb = isVisible ? "Hide" : "Show";
+                return (
+                    <Tooltip
+                        key={name}
+                        title={
+                            isLastVisible ? `${label} is the only panel open` : `${verb} ${label}`
+                        }
                     >
-                        {icon}
-                    </IconButton>
-                </Tooltip>
-            ))}
+                        <Box component="span" sx={{ display: "inline-flex" }}>
+                            <IconButton
+                                size="small"
+                                disabled={isLastVisible}
+                                aria-label={`${verb} ${label}`}
+                                className={`panel-toggle panel-toggle-${name}`}
+                                color={isVisible ? "primary" : "inherit"}
+                                onClick={() => onSectionVisibilityToggle(name)}
+                            >
+                                {icon}
+                            </IconButton>
+                        </Box>
+                    </Tooltip>
+                );
+            })}
         </Toolbar>
     );
 }

--- a/src/components/header_menu/actions.jsx
+++ b/src/components/header_menu/actions.jsx
@@ -40,8 +40,10 @@ export function formatShortcut(shortcut) {
 }
 
 /**
- * The single registry of invocable actions, shared by the quick-action toolbar and the command
- * palette so the two can never drift. Each entry: `{ id, label, group, icon, shortcut, run }`.
+ * The single registry of invocable actions, shared by the quick-action toolbar, the keyboard
+ * shortcuts and the command palette so the three can never drift. Each entry:
+ * `{ id, label, group, icon, shortcut, run, disabled? }`. A `disabled` entry is greyed out on the
+ * toolbar, skipped by the shortcut handler and left out of the palette.
  */
 export function buildActions({
     onUndo,
@@ -50,6 +52,8 @@ export function buildActions({
     onOpenDialog,
     onUseConventionalCell,
     openLocalDialog,
+    canUndo = true,
+    canRedo = true,
 }) {
     return [
         {
@@ -59,6 +63,7 @@ export function buildActions({
             icon: <UndoIcon />,
             shortcut: "Mod+Z",
             run: onUndo,
+            disabled: !canUndo,
         },
         {
             id: "redo",
@@ -67,6 +72,7 @@ export function buildActions({
             icon: <RedoIcon />,
             shortcut: "Mod+Shift+Z",
             run: onRedo,
+            disabled: !canRedo,
         },
         {
             id: "clone",

--- a/src/components/items_list/ItemsList.jsx
+++ b/src/components/items_list/ItemsList.jsx
@@ -18,6 +18,7 @@ import { closeSnackbar, enqueueSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { isTypingTarget } from "../header_menu/actions";
 import { theme } from "../../settings";
 import ItemsListHeader, { buildAddActions } from "./ItemsListHeader";
 
@@ -79,6 +80,10 @@ class ItemsList extends React.Component {
     initControlsSwitchFromKeyboard(event) {
         const { materials, index, onItemClick } = this.props;
         if (!event.shiftKey) return; // Shift key must be down
+        // Shift is also how you type a capital letter. Without this, naming a material "Diamond"
+        // or filtering for "Si" would switch the active material mid-word.
+        if (isTypingTarget(event.target)) return;
+        if (event.metaKey || event.ctrlKey || event.altKey) return;
 
         const nextIndex = materials.length === 1 + index ? 0 : index + 1;
         const previousIndex = index === 0 ? materials.length - 1 : index - 1;
@@ -103,9 +108,12 @@ class ItemsList extends React.Component {
     }
 
     blurListItem() {
-        const { onItemClick, onNameUpdate, index } = this.props;
+        const { materials, onItemClick, onNameUpdate, index } = this.props;
         const { editedName, editedIndex } = this.state;
-        onNameUpdate(editedName, editedIndex);
+        // Clicking a row focuses its name field, so simply browsing the list used to dispatch a
+        // rename on every click-away - each one an undo step for a name that never changed.
+        const edited = editedIndex >= 0 ? materials[editedIndex] : undefined;
+        if (edited && edited.name !== editedName) onNameUpdate(editedName, editedIndex);
         onItemClick(index);
         this.setState({ editedName: null, editedIndex: null });
     }
@@ -173,6 +181,8 @@ class ItemsList extends React.Component {
         const { editedIndex, editedName } = this.state;
         const isBeingEdited = editedIndex === index;
         const isBeingActive = index === indexFromState;
+        // Once per row: describeStructure parses the basis, which is not free for large materials.
+        const structureFacts = describeStructure(entity);
         const dynamicIconColor = isBeingActive ? theme.palette.grey[300] : theme.palette.grey[900];
         const neutralColor = theme.palette.grey[500];
         return (
@@ -286,7 +296,7 @@ class ItemsList extends React.Component {
                             <Typography
                                 variant="caption"
                                 component="span"
-                                title={[entity.formula, ...describeStructure(entity)].join(" · ")}
+                                title={[entity.formula, ...structureFacts].join(" · ")}
                                 sx={{
                                     fontSize: "0.8em",
                                     display: "flex",
@@ -317,7 +327,7 @@ class ItemsList extends React.Component {
                                         flexShrink: 1,
                                     }}
                                 >
-                                    {describeStructure(entity).join(" · ")}
+                                    {structureFacts.join(" · ")}
                                 </Box>
                                 {isUpdated && (
                                     <Tooltip title="Edited since it entered the session">

--- a/src/components/items_list/ItemsListHeader.jsx
+++ b/src/components/items_list/ItemsListHeader.jsx
@@ -1,6 +1,7 @@
 import Dropdown from "@mat3ra/cove/dist/mui/components/dropdown/Dropdown";
 import IconByName from "@mat3ra/cove/dist/mui/components/icon/IconByName";
 import AddIcon from "@mui/icons-material/Add";
+import ClearIcon from "@mui/icons-material/Close";
 import CloneIcon from "@mui/icons-material/Collections";
 import SearchIcon from "@mui/icons-material/Search";
 import Box from "@mui/material/Box";
@@ -63,13 +64,35 @@ function ItemsListHeader({ filter, onFilterChange, shownCount, totalCount, addAc
                 placeholder="Filter by name or formula"
                 value={filter}
                 onChange={(event) => onFilterChange(event.target.value)}
-                inputProps={{ "aria-label": "Filter materials" }}
+                // Escape clears rather than closes: there is nothing to close, and a filter that
+                // hides every material is otherwise a small dead end to type your way out of.
+                onKeyDown={(event) => {
+                    if (event.key !== "Escape" || !filter) return;
+                    event.stopPropagation();
+                    onFilterChange("");
+                }}
+                inputProps={{ "aria-label": "Filter materials", autoComplete: "off" }}
                 InputProps={{
                     startAdornment: (
                         <InputAdornment position="start">
                             <SearchIcon sx={{ fontSize: "1rem", color: theme.palette.grey[600] }} />
                         </InputAdornment>
                     ),
+                    endAdornment: filter ? (
+                        <InputAdornment position="end">
+                            <Tooltip title="Clear filter (Esc)">
+                                <IconButton
+                                    size="small"
+                                    aria-label="Clear filter"
+                                    className="materials-filter-clear"
+                                    onClick={() => onFilterChange("")}
+                                    sx={{ padding: 0.25 }}
+                                >
+                                    <ClearIcon sx={{ fontSize: "0.9rem" }} />
+                                </IconButton>
+                            </Tooltip>
+                        </InputAdornment>
+                    ) : null,
                     sx: { fontSize: "0.8rem" },
                 }}
             />

--- a/src/reducers/InputOutput.ts
+++ b/src/reducers/InputOutput.ts
@@ -7,7 +7,6 @@ import {
     addUpdatedIndices,
     adjustUpdatedIndicesForRemove,
     indicesForAddedMaterials,
-    isMaterialUpdated,
     syncUpdatedIndexBySignature,
 } from "./Material";
 
@@ -74,10 +73,10 @@ export function materialsInsertAt(
         ...state.materials.slice(index),
     ];
     const updatedIndices = state.updatedIndices.map((i) => (i >= index ? i + 1 : i));
-    const restored = { ...state, materials, updatedIndices, index };
-    return isMaterialUpdated(restored, index)
-        ? restored
-        : syncUpdatedIndexBySignature(restored, index);
+    // Shifting every flag at or past the insert point leaves `index` itself unflagged, so the
+    // restored material is re-judged against its own original signature: an edited material that
+    // was removed and put back is still edited.
+    return syncUpdatedIndexBySignature({ ...state, materials, updatedIndices, index }, index);
 }
 
 export function materialsExport(

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -4,7 +4,7 @@
 
 /**
 $header-height: 92px; // menu row (54) + quick-action row (38)
-$footer-height: 54px;
+$footer-height: 36px;
 $crystal-lattice-accordion-height-with-borders: 56px;
 .three-renderer {
   height: calc(100vh - $footer-height - $header-height);
@@ -39,22 +39,22 @@ $crystal-lattice-accordion-height-with-borders: 56px;
 **/
 
 .three-renderer {
-    /* menu row + quick actions + footer: 54 + 38 + 54 */
-    height: calc(100vh - 146px);
+    /* menu row + quick actions + footer: 54 + 38 + 36 */
+    height: calc(100vh - 128px);
 }
 
 #basis-xyz {
-    height: calc(100vh - 318px);
+    height: calc(100vh - 300px);
     overflow-y: hidden;
 }
 
 #basis-xyz .cm-editor {
     font-size: 0.9em;
-    max-height: calc(100vh - 318px);
+    max-height: calc(100vh - 300px);
     resize: vertical;
     overflow-y: auto;
 }
 
 #basis-xyz .cm-editor .cm-scroller {
-    min-height: calc(100vh - 318px);
+    min-height: calc(100vh - 300px);
 }

--- a/tests/cypress/e2e/materials-list/filter-and-count.feature
+++ b/tests/cypress/e2e/materials-list/filter-and-count.feature
@@ -47,3 +47,11 @@ Feature: The materials list can be counted, filtered and added to
   Scenario: The add menu opens the Standata import dialog
     When I select "Import from Standata" from the add material menu
     Then I see Standata dialog
+
+  Scenario: The filter can be cleared without selecting the text
+    When I filter the materials list by "nothing-matches-this"
+    Then I see the empty state for the materials list
+
+    When I clear the materials list filter with the clear button
+    Then I see "3" materials in the list
+    And I see the materials count showing "3"

--- a/tests/cypress/e2e/toolbar/control-availability.feature
+++ b/tests/cypress/e2e/toolbar/control-availability.feature
@@ -1,0 +1,48 @@
+Feature: Controls that cannot do anything say so
+
+  # A control that looks live and does nothing is worse than one that is greyed out: the user
+  # cannot tell a no-op from a bug. These pin down the two places that used to have that problem.
+
+  Background:
+    When I open materials designer page
+    Then I see material designer page
+
+  Scenario: Undo and redo reflect what the history can actually do
+    Then I see the "undo" quick action is "disabled"
+    And I see the "redo" quick action is "disabled"
+
+    When I clone material at index "1"
+    Then I see the "undo" quick action is "enabled"
+    And I see the "redo" quick action is "disabled"
+
+    When I click the "undo" quick action
+    Then I see the "undo" quick action is "disabled"
+    And I see the "redo" quick action is "enabled"
+
+  Scenario: The last panel left open cannot be toggled away
+    Then I see the "SourceEditor" panel toggle is "enabled"
+
+    When I toggle the "ItemsList" panel
+    And I toggle the "ThreeDEditorFullscreen" panel
+    Then I see the "SourceEditor" panel toggle is "disabled"
+    And I see the "ItemsList" panel toggle is "enabled"
+
+    When I toggle the "ItemsList" panel
+    Then I see the "SourceEditor" panel toggle is "enabled"
+
+  Scenario: Browsing the list is not something to undo
+    When I clone material at index "1"
+    Then I see the "undo" quick action is "enabled"
+
+    # Selecting rows moves focus through their name fields; neither the move nor the no-op rename
+    # that follows the click-away is an edit, so browsing must not deepen the history. If it did,
+    # the single undo below would walk back a selection and leave the clone in place.
+    When I select material with index "2" from material designer items list
+    And I select material with index "1" from material designer items list
+    And I select material with index "2" from material designer items list
+
+    When I click the "undo" quick action
+    Then material with following data does not exist in state
+      | path          | index   |
+      | si-clone.json | $INT{2} |
+    And I see the "undo" quick action is "disabled"

--- a/tests/cypress/e2e/toolbar/keyboard-shortcuts.feature
+++ b/tests/cypress/e2e/toolbar/keyboard-shortcuts.feature
@@ -34,3 +34,17 @@ Feature: Keyboard shortcuts drive the app without stealing keys from text fields
     Then material with following data exists in state
       | path          | index   |
       | si-clone.json | $INT{2} |
+
+  Scenario: Shift is a capital letter in a text field, not a material switch
+    When I open materials designer page
+    Then I see material designer page
+    When I clone material at index "1"
+    Then I see status bar showing
+      | group    | text  |
+      | position | 1 / 2 |
+
+    # Shift+D switches material, but only outside a field: typing "Diamond" must not navigate away
+    When I press "shift+d" inside the materials filter
+    Then I see status bar showing
+      | group    | text  |
+      | position | 1 / 2 |

--- a/tests/cypress/support/step_definitions/I filter materials list.ts
+++ b/tests/cypress/support/step_definitions/I filter materials list.ts
@@ -31,3 +31,7 @@ Given("I select {string} from the add material menu", (itemText: string) => {
 Given("I undo the removal", () => {
     itemsList().undoRemove();
 });
+
+Given("I clear the materials list filter with the clear button", () => {
+    itemsList().clearFilterWithButton();
+});

--- a/tests/cypress/support/step_definitions/I use the command palette.ts
+++ b/tests/cypress/support/step_definitions/I use the command palette.ts
@@ -45,3 +45,26 @@ Given("I do not see the {string} panel", (selector: string) => {
     // editor's state survive being toggled away. Cypress treats a zero-width element as not visible.
     new MaterialDesignerPage().designerWidget.browser.get(selector).should("not.be.visible");
 });
+
+/**
+ * Availability of a control on the quick-action row. `disabled` is read off the attribute rather
+ * than by clicking and asserting nothing happened: a control that looks live but does nothing is
+ * the thing being guarded against.
+ */
+Given(
+    "I see the {string} quick action is {string}",
+    (id: string, state: "enabled" | "disabled") => {
+        new MaterialDesignerPage().designerWidget.browser
+            .get(`.quick-action-${id}`)
+            .should(state === "disabled" ? "be.disabled" : "not.be.disabled");
+    },
+);
+
+Given(
+    "I see the {string} panel toggle is {string}",
+    (name: string, state: "enabled" | "disabled") => {
+        new MaterialDesignerPage().designerWidget.browser
+            .get(`.panel-toggle-${name}`)
+            .should(state === "disabled" ? "be.disabled" : "not.be.disabled");
+    },
+);

--- a/tests/cypress/support/widgets/ItemsListWidget.ts
+++ b/tests/cypress/support/widgets/ItemsListWidget.ts
@@ -11,6 +11,7 @@ export class ItemsListWidget extends Widget {
         iconButtonDelete: ".icon-button-delete",
         count: `${wrapper} .materials-count`,
         filterInput: `${wrapper} .materials-filter input`,
+        filterClear: `${wrapper} .materials-filter-clear`,
         rows: `${wrapper} ul>div`,
         emptyState: `${wrapper} .materials-empty-state`,
         addMenuButton: `${wrapper} .add-material-menu`,
@@ -43,6 +44,11 @@ export class ItemsListWidget extends Widget {
 
     clearFilter() {
         this.browser.clearInputValue(this.selectors.filterInput);
+    }
+
+    /** The "x" inside the field, which only exists while the filter has text. */
+    clearFilterWithButton() {
+        this.browser.click(this.selectors.filterClear);
     }
 
     openAddMenu() {


### PR DESCRIPTION
Sixth in the UX chain, stacked on #292. Follow-ups from a review pass over the whole chain's cumulative diff against `dev`.

## The undo stack was recording things the user never did

Four separate paths pushed history entries for non-edits. Together they meant "Undo" was lit up on a fresh page and Mod+Z spent presses on nothing.

| What | Effect |
|---|---|
| Mount effect mirroring the `isLoading` prop | Every session started with one phantom entry — undo enabled before the user touched anything, and the first Mod+Z swapped the state for a copy of itself |
| Selecting a material | Clicking through five materials cost five presses of Mod+Z to get back to the last real change |
| Exporting | `materialsExport` writes a file and returns the state untouched, leaving a duplicate snapshot and an Undo that visibly did nothing |
| Clicking away from a row | Clicking a row focuses its name field, so the click-away fired `onNameUpdate` with an unchanged name |

`setState` grows an options argument: `{ recordHistory: false }` still moves the present and still renders, it just does not deepen the past. Undo and redo keep working across a non-recorded change, and an undo now lands on the state as it was where the edit happened — including which material was selected at the time.

## Controls that cannot act now say so

- **Undo/redo were always enabled**, on the quick-action row and in the Edit menu, whether or not there was anything to undo. The container computed `canUndo`/`canRedo` and then dropped them on the floor — the call site destructured only five of the seven returned values. They are wired through now: the action registry carries a `disabled` flag, the toolbar greys the button out, the shortcut handler still swallows the key (so Mod+Z on an empty history does not fall through to the browser's own undo) but runs nothing, and the command palette leaves unavailable actions out rather than offering a dead end.
- **The last visible panel toggle** looked live and silently did nothing when clicked — the app deliberately keeps one panel on screen. Disabled now, with a tooltip that says why.

## Layout

- **Dragging a divider while a panel was hidden stored a zero** for that panel, which failed the `every size > 0` check on the next load and silently threw the whole saved layout away. A hidden pane now keeps its last known width.
- The stored sizes were read from `localStorage` three times per render through a getter, though allotment consumes `defaultSizes` once on mount. Read once, in the constructor.
- Dead `Grid` import, left behind when the grid layout became allotment panes.

## Status bar

54px of chrome holding two short values stacked under their labels. Label and value now sit on one line and the bar is 36px — **18px back for the 3D canvas**; `main.css` derives its heights from the same total. Its stale doc comment (still describing a SELECTION group that moved into wave.js) and the misnamed `SELECTION_HINTS` are gone, and the hint renders `Ctrl+K` rather than a hardcoded `⌘K` off-Mac.

## Smaller

- Shift+U / Shift+D switch material on a window keydown listener with no guard for where the key landed, so **typing a capital letter into a field switched the active material mid-word**. Always true of the rename field, much easier to hit once the filter box moved to the top of the list. Now reuses `isTypingTarget` and ignores combinations carrying another modifier.
- The materials filter can be cleared with an "x" in the field or by pressing Escape, rather than only by selecting the text — a filter matching nothing was otherwise a small dead end to type your way out of.
- `describeStructure` is computed once per row rather than twice; it parses the basis, which is not free for large materials.
- `materialsInsertAt` dropped a branch that could never be taken: shifting every flag at or past the insert point leaves that index unflagged by construction.

## Tests

New `toolbar/control-availability.feature` covers undo/redo availability tracking the history, the last panel refusing to close, and browsing the list not deepening the stack (a single undo after three selections still removes the clone). Extended `keyboard-shortcuts.feature` with Shift+D inside the filter, and `filter-and-count.feature` with the clear button.

Full suite green: 90 tests, 33 executed, 57 skipped (notebook health checks), 0 failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tg648kyhgbSwikBzhSjvXg)_